### PR TITLE
Added: Option to use NonLinSIM and HHTSIM as the time integrator

### DIFF
--- a/main_CahnHilliard.C
+++ b/main_CahnHilliard.C
@@ -70,12 +70,12 @@ int main (int argc, char** argv)
 {
   Profiler prof(argv[0]);
 
-  int i, ndim = 3;
-  char* infile = 0;
+  int ndim = 3;
+  char* infile = nullptr;
 
-  IFEM::Init(argc,argv);
+  IFEM::Init(argc,argv,"Cahn-Hilliard equation solver");
 
-  for (i = 1; i < argc; i++)
+  for (int i = 1; i < argc; i++)
     if (SIMoptions::ignoreOldOptions(argc,argv,i))
       ; // ignore the obsolete option
     else if (!strcmp(argv[i],"-2D"))
@@ -97,11 +97,7 @@ int main (int argc, char** argv)
     return 0;
   }
 
-  IFEM::cout <<"\n >>> IFEM Cahn-Hilliard equation solver <<<"
-             <<"\n ==========================================\n"
-             <<"\n Executing command:\n";
-  for (i = 0; i < argc; i++) IFEM::cout <<" "<< argv[i];
-  IFEM::cout <<"\n\nInput file: "<< infile;
+  IFEM::cout <<"\nInput file: "<< infile;
   IFEM::getOptions().print(IFEM::cout);
   IFEM::cout << std::endl;
 

--- a/main_FractureDynamics.C
+++ b/main_FractureDynamics.C
@@ -278,16 +278,15 @@ int main (int argc, char** argv)
 {
   Profiler prof(argv[0]);
 
-  int  i;
-  char* infile = 0;
+  char* infile = nullptr;
   char coupling = 1;
   char integrator = 1;
   bool twoD = false;
   bool adaptive = false;
 
-  IFEM::Init(argc,argv);
+  IFEM::Init(argc,argv,"Fracture dynamics solver");
 
-  for (i = 1; i < argc; i++)
+  for (int i = 1; i < argc; i++)
     if (SIMoptions::ignoreOldOptions(argc,argv,i))
       ; // ignore the obsolete option
     else if (!strcmp(argv[i],"-2D"))
@@ -331,11 +330,7 @@ int main (int argc, char** argv)
   if (adaptive)
     IFEM::getOptions().discretization = ASM::LRSpline;
 
-  IFEM::cout <<"\n >>> IFEM Fracture dynamics solver <<<"
-             <<"\n =====================================\n"
-             <<"\n Executing command:\n";
-  for (i = 0; i < argc; i++) IFEM::cout <<" "<< argv[i];
-  IFEM::cout <<"\n\nInput file: "<< infile;
+  IFEM::cout <<"\nInput file: "<< infile;
   IFEM::getOptions().print(IFEM::cout);
   IFEM::cout << std::endl;
 


### PR DESCRIPTION
Should be merged before #4, when time comes..

This adds the option to use the nonlinear (static and dynamic) solution drivers with the fracture elasticity simulator.