### PR TITLE
Print boundary force resultant to file

### DIFF
--- a/SIMFractureDynamics.h
+++ b/SIMFractureDynamics.h
@@ -57,9 +57,17 @@ public:
     {
       std::ofstream os(energFile, tp.step == 1 ? std::ios::out : std::ios::app);
 
+      RealArray RF;
+      this->S1.getCurrentReactions(RF,this->S1.getSolution(0));
+
       if (tp.step == 1)
+      {
         os <<"#t eps_e external_energy eps+ eps- eps_b |c|"
-           <<" eps_d-eps_d(0) eps_d"<< std::endl;
+           <<" eps_d-eps_d(0) eps_d";
+        for (size_t i = 1; i < RF.size(); i++)
+          os <<" load_"<< char('W'+i);
+        os << std::endl;
+      }
 
       const Vector& n1 = this->S1.getGlobalNorms();
       const Vector& n2 = this->S2.getGlobalNorms();
@@ -70,6 +78,8 @@ public:
       os <<" "<< (n2.size() > 2 ? n2[1] : 0.0);
       os <<" "<< (n2.size() > 1 ? n2[n2.size()-2] : 0.0);
       os <<" "<< (n2.size() > 0 ? n2.back() : 0.0);
+      for (size_t i = 1; i < RF.size(); i++)
+        os <<" "<< utl::trunc(RF[i]);
       os << std::endl;
     }
 

--- a/SIMFractureDynamics.h
+++ b/SIMFractureDynamics.h
@@ -57,15 +57,19 @@ public:
     {
       std::ofstream os(energFile, tp.step == 1 ? std::ios::out : std::ios::app);
 
-      RealArray RF;
+      size_t i;
+      Vector BF, RF;
+      this->S1.getBoundaryForce(BF,this->S1.getSolutions(),tp);
       this->S1.getCurrentReactions(RF,this->S1.getSolution(0));
 
       if (tp.step == 1)
       {
         os <<"#t eps_e external_energy eps+ eps- eps_b |c|"
            <<" eps_d-eps_d(0) eps_d";
-        for (size_t i = 1; i < RF.size(); i++)
-          os <<" load_"<< char('W'+i);
+        for (i = 0; i < BF.size(); i++)
+          os <<" load_"<< char('X'+i);
+        for (i = 1; i < RF.size(); i++)
+          os <<" react_"<< char('W'+i);
         os << std::endl;
       }
 
@@ -78,7 +82,9 @@ public:
       os <<" "<< (n2.size() > 2 ? n2[1] : 0.0);
       os <<" "<< (n2.size() > 1 ? n2[n2.size()-2] : 0.0);
       os <<" "<< (n2.size() > 0 ? n2.back() : 0.0);
-      for (size_t i = 1; i < RF.size(); i++)
+      for (i = 0; i < BF.size(); i++)
+        os <<" "<< utl::trunc(BF[i]);
+      for (i = 1; i < RF.size(); i++)
         os <<" "<< utl::trunc(RF[i]);
       os << std::endl;
     }


### PR DESCRIPTION
Sammen med OPM/IFEM-Elasticity#5 gir denne mulighet for å skrive ut lasten til energyfile.
Reaksjonskreftene skrives også ut, men de er vel mindre interessante nå