### PR TITLE
added: sub-iterations for quasi static simulations

### DIFF
--- a/CahnHilliard.C
+++ b/CahnHilliard.C
@@ -23,7 +23,8 @@
 
 CahnHilliard::CahnHilliard (unsigned short int n) : IntegrandBase(n),
   Gc(1.0), smearing(1.0), maxCrack(1.0e-3), stabk(0.0), scale2nd(4.0),
-  initial_crack(nullptr), tensileEnergy(nullptr), Lnorm(0)
+  pgamma(1.0), pthresh(0.0), initial_crack(nullptr), tensileEnergy(nullptr),
+  Lnorm(0)
 {
   primsol.resize(1);
 }
@@ -40,6 +41,10 @@ bool CahnHilliard::parse (const TiXmlElement* elem)
     maxCrack = atof(value);
   else if ((value = utl::getValue(elem,"stabilization")))
     stabk = atof(value);
+  else if ((value = utl::getValue(elem,"penalty_factor"))) {
+    pgamma = atof(value);
+    utl::getAttribute(elem,"threshold",pthresh);
+  }
   else if ((value = utl::getValue(elem,"initial_crack")))
   {
     std::string type;
@@ -67,6 +72,11 @@ void CahnHilliard::printLog () const
     IFEM::cout <<"\n\tInitial crack specified as a function.";
   if (scale2nd == 2.0)
     IFEM::cout <<"\n\tUsing fourth-order phase field.";
+  if (pgamma != 1.0)
+    IFEM::cout <<"\n\tEnforcing irreversibility using penalty formulation.";
+  else
+    IFEM::cout <<"\n\tEnforcing irreversibility using history buffer.";
+
   IFEM::cout << std::endl;
 }
 
@@ -74,7 +84,7 @@ void CahnHilliard::printLog () const
 void CahnHilliard::setMode (SIM::SolutionMode mode)
 {
   m_mode = mode;
-  primsol.resize(mode == SIM::RECOVERY ? 1 : 0);
+  primsol.resize(mode == SIM::RECOVERY ? 1 : (pgamma != 1.0 ? 1 : 0));
 }
 
 
@@ -94,15 +104,23 @@ bool CahnHilliard::evalInt (LocalIntegral& elmInt, const FiniteElement& fe,
     double dist = (*initial_crack)(X);
     if (dist < smearing)
       H = (0.25*Gc/smearing) * (1.0/maxCrack-1.0) * (1.0-dist/smearing);
+  } else {
+    // Update history field
+    if (pgamma == 1.0 && tensileEnergy)
+      H = std::max(H,(*tensileEnergy)[fe.iGP]);
+    else
+      H = (*tensileEnergy)[fe.iGP];
   }
-
-  // Update history field
-  if (tensileEnergy)
-    H = std::max(H,(*tensileEnergy)[fe.iGP]);
 
   double scale = 1.0 + 4.0*smearing*(1.0-stabk)*H/Gc;
   double s1JxW = scale*fe.detJxW;
   double s2JxW = scale2nd*smearing*smearing*fe.detJxW;
+  double d = 0.0;
+  if (pgamma != 1.0) {
+    d = fe.N.dot(static_cast<ElmMats&>(elmInt).vec.front());
+    if (d < pthresh)
+      s1JxW -= 1.0/pgamma*fe.detJxW;
+  }
 
   Matrix& A = static_cast<ElmMats&>(elmInt).A.front();
   for (size_t i = 1; i <= fe.N.size(); i++)

--- a/CahnHilliard.C
+++ b/CahnHilliard.C
@@ -116,8 +116,8 @@ bool CahnHilliard::evalInt (LocalIntegral& elmInt, const FiniteElement& fe,
   double s1JxW = scale*fe.detJxW;
   double s2JxW = scale2nd*smearing*smearing*fe.detJxW;
   double d = 0.0;
-  if (pgamma != 1.0) {
-    d = fe.N.dot(static_cast<ElmMats&>(elmInt).vec.front());
+  if (pgamma != 1.0 && !elmInt.vec.empty() &&!elmInt.vec.front().empty()) {
+    d = fe.N.dot(elmInt.vec.front());
     if (d < pthresh)
       s1JxW -= 1.0/pgamma*fe.detJxW;
   }

--- a/CahnHilliard.h
+++ b/CahnHilliard.h
@@ -98,6 +98,8 @@ protected:
   double maxCrack; //!< Maximum value in initial crack
   double stabk;    //!< Stabilization parameter
   double scale2nd; //!< Scaling factor in front of second order term
+  double pgamma;   //!< Penalty factor. If != 1.0, penalty formulation is used
+  double pthresh;  //!< Threshold for penalty formulation
 
 private:
   RealFunc*        initial_crack; //!< For generating initial history field

--- a/SIMDynElasticity.h
+++ b/SIMDynElasticity.h
@@ -59,6 +59,12 @@ public:
     exporter.setFieldValue("u",this,&dSim.getSolution());
   }
 
+  //! \brief Returns true if simulator is quasi-static
+  bool quasiStatic() const
+  {
+    return strcmp(dSim.inputContext, "nonlinearsolver") == 0;
+  }
+
   //! \brief Initializes the problem.
   bool init(const TimeStep&)
   {
@@ -202,6 +208,9 @@ public:
   //! \param[in] tp Time stepping parameters
   SIM::ConvStatus solveIteration(TimeStep& tp)
   {
+    if (quasiStatic())
+      return dSim.solveStep(tp);
+
     return dSim.solveIteration(tp);
   }
 

--- a/SIMFractureDynamics.h
+++ b/SIMFractureDynamics.h
@@ -226,6 +226,50 @@ public:
 #endif
   }
 
+  SIM::ConvStatus checkConvergence(const TimeStep& tp,
+                                   SIM::ConvStatus status1,
+                                   SIM::ConvStatus status2)
+  {
+    if (!this->S1.quasiStatic())
+      return this->Coupling<SolidSolver,PhaseSolver>::checkConvergence(tp, status1, status2);
+
+    if (status1 != SIM::CONVERGED || status2 != SIM::CONVERGED)
+      return SIM::OK;
+
+    // Compute residual
+    this->S1.setMode(SIM::RHS_ONLY);
+    if (!this->S1.assembleSystem(tp.time,this->S1.getSolutions(),false))
+      return SIM::DIVERGED;
+
+    Vector residual;
+    this->S1.extractLoadVec(residual);
+
+    eHistory.resize(eHistory.size()+1);
+    double dummy;
+    this->S1.iterationNorms(residual, residual, dummy, eHistory.back(), dummy);
+
+    if (eHistory.size() > 1) {
+      double beta = atan2(eHistory[eHistory.size()-2]-eHistory.back(),
+                          eHistory.front()-eHistory.back()) * 180 / M_PI;
+
+      IFEM::cout << "FractureDynamics::checkConvergence: beta = " <<  beta << std::endl;
+    }
+
+    IFEM::cout << "FractureDynamics::checkConvergence: |r| = " << eHistory.back() << std::endl;
+    if (eHistory.back() < 1e-4) {
+      eHistory.clear();
+      return SIM::CONVERGED;
+    }
+
+    static const int maxSubIt = 50; // TODO: Max 50 subiterations hardcoded
+    if (eHistory.size() > maxSubIt) {
+      std::cerr << "FractureDynamics::checkConvergence: Did not converge in maxSubIt sub-iterations, bailing.." << std::endl;
+      return SIM::DIVERGED;
+    }
+
+    return SIM::OK;
+  }
+
 private:
   std::string energFile; //!< File name for global energy output
   std::string infile;    //!< Input file parsed
@@ -233,6 +277,7 @@ private:
   double    aMin; //!< Minimum element area
   Vectors   sols; //!< Solution state to transfer onto refined mesh
   RealArray hsol; //!< History field to transfer onto refined mesh
+  RealArray eHistory; //!< Energy history for quasi-static simulations
 };
 
 #endif

--- a/SIMFractureDynamics.h
+++ b/SIMFractureDynamics.h
@@ -248,20 +248,21 @@ public:
     double dummy;
     this->S1.iterationNorms(residual, residual, dummy, eHistory.back(), dummy);
 
+    IFEM::cout << "   subit=" << eHistory.size()-1 <<" conv=" << eHistory.back()/eHistory.front();
     if (eHistory.size() > 1) {
       double beta = atan2(eHistory[eHistory.size()-2]-eHistory.back(),
                           eHistory.front()-eHistory.back()) * 180 / M_PI;
 
-      IFEM::cout << "FractureDynamics::checkConvergence: beta = " <<  beta << std::endl;
+      IFEM::cout << " beta=" <<  beta;
     }
+    IFEM::cout << std::endl;
 
-    IFEM::cout << "FractureDynamics::checkConvergence: |r| = " << eHistory.back() << std::endl;
-    if (eHistory.back() < 1e-4) {
+    if (eHistory.back()/eHistory.front() < 1e-4) {
       eHistory.clear();
       return SIM::CONVERGED;
     }
 
-    static const int maxSubIt = 50; // TODO: Max 50 subiterations hardcoded
+    static const int maxSubIt = 1000; // TODO: Max 50 subiterations hardcoded
     if (eHistory.size() > maxSubIt) {
       std::cerr << "FractureDynamics::checkConvergence: Did not converge in maxSubIt sub-iterations, bailing.." << std::endl;
       return SIM::DIVERGED;

--- a/SIMPhaseField.h
+++ b/SIMPhaseField.h
@@ -76,6 +76,8 @@ public:
     this->setMode(SIM::INIT);
     this->setQuadratureRule(Dim::opt.nGauss[0],true);
     this->registerField("phasefield",phasefield);
+    phasefield.resize(this->getNoDOFs());
+    phasefield.fill(1.0);
     return true;
   }
 
@@ -151,7 +153,7 @@ public:
       static_cast<CahnHilliard*>(Dim::myProblem)->scaleSmearing(0.5);
 
     this->setMode(SIM::STATIC);
-    if (!this->assembleSystem())
+    if (!this->assembleSystem(Vectors(1,phasefield)))
       return false;
 
     if (!this->solveSystem(phasefield,0))

--- a/SIMPhaseField.h
+++ b/SIMPhaseField.h
@@ -76,8 +76,6 @@ public:
     this->setMode(SIM::INIT);
     this->setQuadratureRule(Dim::opt.nGauss[0],true);
     this->registerField("phasefield",phasefield);
-    phasefield.resize(this->getNoDOFs());
-    phasefield.fill(1.0);
     return true;
   }
 

--- a/Test/Rectangle-p1.xinp
+++ b/Test/Rectangle-p1.xinp
@@ -3,7 +3,7 @@
 <simulation>
 
   <geometry Lx="0.1" Ly="0.04">
-    <refine type="uniform" patch="1" u="94" v="37"/>
+    <refine type="uniform" patch="1" u="400" v="160"/>
     <topologysets>
       <set name="Loaded" type="edge">
         <item patch="1">3 4</item>
@@ -18,6 +18,7 @@
       if(below(dX,0.0),abs(dY),sqrt(dX*dX+dY*dY))
     </initial_crack>
     <Lnorm>1</Lnorm>
+    <penalty_factor threshold="0.01">1e-12</penalty_factor>
   </cahnhilliard>
 
   <elasticity>
@@ -33,7 +34,7 @@
 
   <newmarksolver rho_inf="0.5">
     <timestepping>
-      <step start="0.0" end="1.2e-4">4.95e-7</step>
+      <step start="0.0" end="80e-6">1e-7</step>
     </timestepping>
   </newmarksolver>
 


### PR DESCRIPTION
use -qstatic -semiimplicit

currently the tolerance for the loop is hardcoded to 1e-4

needs https://github.com/OPM/IFEM/pull/35
