### PR TITLE
Fixed/updated quasistatic semiimplicit simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ else()
                          ${PROJECT_SOURCE_DIR}/Test/*_CH.reg)
   file(GLOB FD_TESTFILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                          ${PROJECT_SOURCE_DIR}/Test/*_FD.reg)
-  list(REMOVE_ITEM CH_TESTFILES Rectangle-p2_penalty_CH.reg) # Disabled due to merge order. Re-enable when penalty in ch is merged.
   foreach(TESTFILE ${CH_TESTFILES})
     ifem_add_test(${TESTFILE} CahnHilliard)
   endforeach()

--- a/CahnHilliard.h
+++ b/CahnHilliard.h
@@ -17,11 +17,8 @@
 #include "IntegrandBase.h"
 
 
-class AnaSol;
-
-
 /*!
-  \brief Class representing the integrand of the 2. order Cahn Hilliard problem.
+  \brief Class representing the integrand of a 2nd order Cahn Hilliard problem.
 */
 
 class CahnHilliard : public IntegrandBase
@@ -46,9 +43,6 @@ public:
   //! \brief Initializes the integrand with the number of integration points.
   //! \param[in] nGp Total number of interior integration points
   virtual void initIntegration(size_t nGp, size_t);
-
-  //! \brief Returns that this integrand has no explicit boundary contributions.
-  virtual bool hasBoundaryTerms() const { return true; }
 
   //! \brief Evaluates the integrand at an interior point.
   //! \param elmInt The local integral object to receive the contributions
@@ -85,9 +79,8 @@ public:
 
   //! \brief Sets the pointer to the tensile energy buffer.
   void setTensileEnergy(const RealArray* tens) { tensileEnergy = tens; }
-
-  //! \brief Set flux function associated with Neumann boundary
-  void setFlux(VecFunc* f) { flux=f; }
+  //! \brief Sets the flux function associated with the Neumann boundary.
+  void setFlux(VecFunc* f) { flux = f; }
 
   //! \brief Returns the initial crack function.
   RealFunc* initCrack() { return initial_crack; }
@@ -98,7 +91,7 @@ public:
   //! \note The Integrand object is allocated dynamically and has to be deleted
   //! manually when leaving the scope of the pointer variable receiving the
   //! returned pointer value.
-  virtual NormBase* getNormIntegrand(AnaSol*) const;
+  virtual NormBase* getNormIntegrand(AnaSol* a) const;
 
   //! \brief Returns the critical fracture energy.
   double getCriticalFracEnergy() const { return Gc; }
@@ -113,7 +106,7 @@ protected:
   double maxCrack; //!< Maximum value in initial crack
   double stabk;    //!< Stabilization parameter
   double scale2nd; //!< Scaling factor in front of second order term
-  double pgamma;   //!< Penalty factor (if positive) for crack irreversibility
+  double gammaInv; //!< Penalty factor (if positive) for crack irreversibility
   double pthresh;  //!< Penalty formulation phase field threshold
 
 private:
@@ -128,7 +121,7 @@ public:
 
 
 /*!
-  \brief Class representing the integrand of the 4. order Cahn Hilliard problem.
+  \brief Class representing the integrand of a 4th order Cahn Hilliard problem.
 */
 
 class CahnHilliard4 : public CahnHilliard
@@ -159,7 +152,7 @@ class CahnHilliardNorm : public NormBase
 {
 public:
   //! \brief The constructor forwards to the parent class constructor.
-  CahnHilliardNorm(CahnHilliard& p, int Ln, const AnaSol* asol=nullptr);
+  CahnHilliardNorm(CahnHilliard& p, int Ln, const AnaSol* a = nullptr);
   //! \brief Empty destructor.
   virtual ~CahnHilliardNorm() {}
 

--- a/SIMDynElasticity.h
+++ b/SIMDynElasticity.h
@@ -33,7 +33,7 @@ public:
   SIMDynElasticity() : dSim(*this)
   {
     Dim::myHeading = "Elasticity solver";
-    vtfStep = subIter = 0;
+    vtfStep = 0;
   }
 
   //! \brief Empty destructor.
@@ -184,11 +184,8 @@ public:
   //! \brief Returns a const reference to the global norms.
   const Vector& getGlobalNorms() const { return gNorm; }
 
-  //! \brief Parses sub-iteration parameters from an XML element.
-  void parseSubiteration(const TiXmlElement* elem)
-  {
-    utl::getAttribute(elem,"type",subIter);
-  }
+  //! \brief Dummy method.
+  void parseStaggering(const TiXmlElement*) {}
 
   //! \brief Dummy method.
   void setEnergyFile(const std::string&) {}
@@ -210,7 +207,9 @@ public:
   //! \param[in] tp Time stepping parameters
   SIM::ConvStatus solveIteration(TimeStep& tp)
   {
-    return subIter == 1 ? dSim.solveStep(tp) : dSim.solveIteration(tp);
+    TimeStep myTp(tp); // Make a copy to avoid destroying the iteration counter
+    dSim.setSubIteration(tp.iter == 0 ? DynSIM::FIRST : DynSIM::ITER);
+    return dSim.solveStep(myTp);
   }
 
   //! \brief Returns the maximum number of iterations.
@@ -258,7 +257,6 @@ private:
   Matrix eNorm;   //!< Element norm values
   Vector gNorm;   //!< Global norm values
   int    vtfStep; //!< VTF file step counter
-  int    subIter; //!< Sub-iteration type flag
 };
 
 #endif

--- a/Test/Rectangle-p2_CH.reg
+++ b/Test/Rectangle-p2_CH.reg
@@ -1,25 +1,33 @@
 Rectangle-p2_CH.xinp -2D
 
-Neumann code 1000000 direction -1 (expression): exp(-x/(2\*0.1))/(2\*0.1) \| 0
-Analytical solution: Expression
-Variables=l0=0.1;
-Primary=1 - exp(-x/(2\*l0))
-Secondary=exp(-x/(2\*l0))/(2\*l0)
-Critical fracture energy density: 3
-Smearing factor: 0.1
-Max value in crack: 0.001
+	Length in X = 10
+	Topology sets: Left (1,1,1D)
+	               Right (1,2,1D)
+	Raising order of P1 1 1
+	Refining P1 999 0
+	Dirichlet code 1: (fixed)
+	Neumann code 1000000 direction -1 (expression): exp(-x/(2\*0.1))/(2\*0.1) \| 0
+	Analytical solution: Expression
+	Variables=l0=0.1;
+	Primary=1 - exp(-x/(2\*l0))
+	Secondary=exp(-x/(2\*l0))/(2\*l0)
+	Critical fracture energy density: 3
+	Smearing factor: 0.1
+	Max value in crack: 0.001
+	Enforcing crack irreversibility using history buffer.
+	Constraining P1 E1 in direction(s) 1
 Number of elements    1000
 Number of nodes       3006
 Number of dofs        3006
 Number of unknowns    3003
 L2-norm            : 0.984413
-Max phasefield     : 1 node
+Max phasefield     : 1
   L1-norm: |c^h| = (|c^h|)       : 9.8
   Normalized L1-norm: |c^h|/V    : 0.98
   Dissipated energy:       eps_d : 1.5
   L2-norm: |c^h| = (c^h,c^h)^0.5 : 3.11448
-  H1-norm: |c^h| = a(c^h,c^h)^0.5 : 1.58114
-  L2-norm: |c|   = (c^h,c^h)^0.5 : 3.11448
-  H1-norm: |c|   = a(c,c)^0.5 : 1.58114
-  L2-norm: |e|   = (e^h,e^h)^0.5 : 6.11151e-08
-  H1-norm: |e|   = a(e,e)^0.5 : 9.31832e-05
+  H1-norm: |c^h| = a(c^h,c^h)^.5 : 1.58114
+  L2-norm: |c|   = (c,c)^0.5     : 3.11448
+  H1-norm: |c|   = a(c,c)^0.5    : 1.58114
+  L2-norm: |e|   = (e,e)^0.5     : 6.11151e-08
+  H1-norm: |e|   = a(e,e)^0.5    : 9.31832e-05

--- a/Test/Rectangle-p2_CH.xinp
+++ b/Test/Rectangle-p2_CH.xinp
@@ -2,9 +2,9 @@
 
 <simulation>
 
-  <geometry Lx="10" Ly="1">
+  <geometry Lx="10">
     <raiseorder patch="1" u="1" v="1"/>
-    <refine type="uniform" patch="1" u="999"/>
+    <refine patch="1" u="999"/>
     <topologysets>
       <set name="Left" type="edge">
         <item patch="1">1</item>

--- a/Test/Rectangle-p2_penalty_CH.reg
+++ b/Test/Rectangle-p2_penalty_CH.reg
@@ -19,6 +19,6 @@ Number of dofs        3006
 Number of unknowns    3003
 Loading initial condition for "phasefield" component 1
 from expression function: 1.0 - exp(-x/0.2)
-L2-norm            : 0.983758
+L2-norm            : 0.984413
 Max phasefield     : 1
-  Dissipated energy:       eps_d : 1.59696
+  Dissipated energy:       eps_d : 1.5

--- a/main_FractureDynamics.C
+++ b/main_FractureDynamics.C
@@ -69,8 +69,8 @@ protected:
     {
       const TiXmlElement* child = elem->FirstChildElement();
       for (; child; child = child->NextSiblingElement())
-        if (!strcasecmp(child->Value(),"subiterations"))
-          this->S1.parseSubiteration(child);
+        if (!strncasecmp(child->Value(),"stag",4))
+          this->S1.parseStaggering(child);
         else
           this->SIMSolver<T>::parse(child);
     }
@@ -166,7 +166,7 @@ int runSimulator3 (const FDargs& args)
   const char* contx = Integrator::inputContext;
   if (args.integrator == 3 && args.coupling == 2)
   {
-    typedef SIMFractureQstatic<ElSolver,PhaseSolver,Cpl> Coupler;
+    typedef SIMFractureQstatic<ElSolver,PhaseSolver> Coupler;
     return runCombined<ElSolver,PhaseSolver,Coupler,Solver>(args.inpfile,contx);
   }
   else


### PR DESCRIPTION
Changed: Removed subiteration type=2, was nonworking/unfinished/confusing
Changed: The template class SIMFractureStatic is instantiated for SIMCoupledSI only,
such that we can access the maxIter member easily.
Fixed: Let DynSIM::solveStep work on a copy of the TimeStep object when doing
sub-iterations. Otherwise the iteration counter is messed up.
Also set the subiteration flag in DynSIM to FIRST when we are in the first iterations.

Requires OPM/IFEM#100