### PR TITLE
Fixed: Interpretation of the Lnorm member for all norms

### DIFF
--- a/CahnHilliard.h
+++ b/CahnHilliard.h
@@ -116,6 +116,8 @@ public:
   double scaleSmearing(double s) { return smearing *= smearing > l0 ? s : 1.0; }
   //! \brief Returns \e true if d=1-c is to be the primary unknown (and not c).
   bool useDformulation() const { return gammaInv < 0.0 && tensileEnergy; }
+  //! \brief Returns the L-norm type to be integrated.
+  int getRefinementNorm() const { return Lnorm; }
 
 private:
   //! \brief Evaluates the integrand at an interior point.

--- a/Test/Rectangle-p2_CH.reg
+++ b/Test/Rectangle-p2_CH.reg
@@ -6,11 +6,10 @@ Rectangle-p2_CH.xinp -2D
 	Raising order of P1 1 1
 	Refining P1 999 0
 	Dirichlet code 1: (fixed)
-	Neumann code 1000000 direction -1 (expression): exp(-x/(2\*0.1))/(2\*0.1) \| 0
+	Neumann code 1000000 direction -1 (expression): exp(-x/0.2)/0.2 \| 0
 	Analytical solution: Expression
-	Variables=l0=0.1;
-	Primary=1 - exp(-x/(2\*l0))
-	Secondary=exp(-x/(2\*l0))/(2\*l0)
+	Primary=1.0-exp(-x/0.2)
+	Secondary=exp(-x/0.2)/0.2
 	Critical fracture energy density: 3
 	Smearing factor: 0.1
 	Max value in crack: 0.001
@@ -23,10 +22,9 @@ Number of unknowns    3003
 L2-norm            : 0.984413
 Max phasefield     : 1
   Dissipated energy:               eps_d : 1.5
-  L1-norm: |c^h| = (|c^h|)        : 9.8
-  Normalized L1-norm: |c^h|/V     : 0.98
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 3.11448
-  H1-norm: |c^h| = a(c^h,c^h)^0.5 : 1.58114
+  Normalized L2-norm: |c^h|/V^0.5 : 0.984886
   L2-norm: |c|   = (c,c)^0.5      : 3.11448
+  H1-norm: |c^h| = a(c^h,c^h)^0.5 : 1.58114
   H1-norm: |c|   = a(c,c)^0.5     : 1.58114
   H1-norm: |e|   = a(e,e)^0.5     : 0.000147336

--- a/Test/Rectangle-p2_CH.xinp
+++ b/Test/Rectangle-p2_CH.xinp
@@ -20,14 +20,15 @@
     <smearing>0.1</smearing>
     <boundaryconditions>
       <dirichlet set="Left" comp="1"/>
-      <neumann set="Right" direction="-1" type="expression">exp(-x/(2*0.1))/(2*0.1) | 0</neumann>
+      <neumann set="Right" direction="-1" type="expression">
+        exp(-x/0.2)/0.2 | 0
+      </neumann>
     </boundaryconditions>
     <anasol type="expression">
-      <variables>l0=0.1</variables>
-      <primary>1 - exp(-x/(2*l0))</primary>
-      <secondary>exp(-x/(2*l0))/(2*l0)</secondary>
+      <primary>1.0-exp(-x/0.2)</primary>
+      <secondary>exp(-x/0.2)/0.2</secondary>
     </anasol>
-    <Lnorm>1</Lnorm>
+    <Lnorm>2</Lnorm>
   </cahnhilliard>
 
   <discretization>


### PR DESCRIPTION
The finalOp now applies such that we don't have to do the explict sqrt-ing.
Force Lnorm=2 when analytical solution due to the L2-norm calculation.
Removed the projection prefixes for the norm output to VTF,
because the projections are not used in the norm evaluation.