### PR TITLE
Fix build failure

### DIFF
--- a/SIMPhaseField.h
+++ b/SIMPhaseField.h
@@ -465,12 +465,12 @@ public:
           ok &= pch->transferCntrlPtVars(basis,oldHn,newHp,nGp);
           break;
         case 'N':
-          jtH = itH + basis->nElements()*pow(nGp,Dim::dimension);
+          jtH = itH + basis->nElements()*pow(nGp, static_cast<int>(Dim::dimension));
           ok &= pch->transferGaussPtVarsN(basis,RealArray(itH,jtH),newHp,nGp);
           itH = jtH;
           break;
         default:
-          jtH = itH + basis->nElements()*pow(nGp,Dim::dimension);
+          jtH = itH + basis->nElements()*pow(nGp, static_cast<int>(Dim::dimension));
           ok &= pch->transferGaussPtVars(basis,RealArray(itH,jtH),newHp,nGp);
           itH = jtH;
         }


### PR DESCRIPTION
This is needed on my system, otherwise there's an error for ambiguous overloaded call `pow(int&, SIM::<unnamed enum>)`.