### PR TITLE
Fixed: Compute poroelastic scaling during initialization

### DIFF
--- a/SIMDynElasticity.h
+++ b/SIMDynElasticity.h
@@ -59,12 +59,12 @@ public:
   }
 
   //! \brief Initializes the problem.
-  bool init(const TimeStep&, bool = false) override
+  bool init(const TimeStep& tp, bool = false) override
   {
     dSim.initPrm();
     dSim.initSol(dynamic_cast<NewmarkSIM*>(&dSim) ? 3 : 1);
 
-    bool ok = this->setMode(SIM::INIT);
+    bool ok = this->setMode(SIM::INIT) && this->getIntegrand()->init(tp.time);
     this->setQuadratureRule(Dim::opt.nGauss[0],true);
     this->registerField("solution",dSim.getSolution());
     return this->setInitialConditions() && ok;

--- a/main_FractureDynamics.C
+++ b/main_FractureDynamics.C
@@ -128,7 +128,7 @@ int runCombined (char* infile, double stopTime, const char* context)
     return 2;
 
   // Initialize the solution fields
-  if (!frac.init(TimeStep()))
+  if (!frac.init(solver.getTimePrm()))
     return 2;
 
   if (elastoSim.opt.dumpHDF5(infile))


### PR DESCRIPTION
Downstream of OPM/IFEM-PoroElasticity#32.

With this you can use a varying time step and apply a scaling computed based on the initial time step size instead of specifying on input file. Still you need to specify it when running adaptively (when we get to that point). Resolve that later.