### PR TITLE
Fixed: The linear static solver does not solve incrementally.

### DIFF
--- a/Test/Miehe71-lstatic_FD.reg
+++ b/Test/Miehe71-lstatic_FD.reg
@@ -1,0 +1,209 @@
+Miehe71.xinp -lstatic -nocrack -stopTime 50
+
+Input file: Miehe71.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Simulation stop time: 50
+0. Parsing input file(s).
+1. Elasticity solver
+Parsing input file Miehe71.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]^2
+	Length in X = 5
+	Length in Y = 5
+  Parsing <refine>
+  Parsing <topologysets>
+	Topology sets: Left (1,1,1D)
+	               Right (1,2,1D)
+	               TopBottom (1,3,1D) (1,4,1D)
+  Parsing <refine>
+	Refining P1 19 19
+  Parsing <topologysets>
+Parsing <cahnhilliard>
+Parsing <phasefield>
+Parsing <poroelasticity>
+Parsing <elasticity>
+  Parsing <isotropic>
+	Material code 0: 254.8 0.3 700
+  Parsing <dirichlet>
+	Dirichlet code 2: (fixed)
+  Parsing <dirichlet>
+	Dirichlet code 1: (fixed)
+  Parsing <dirichlet>
+	Dirichlet code 1000001 (ramp): 3 \* Ramp(t,10)
+Parsing <newmarksolver>
+Parsing <timestepping>
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 2
+2. Time integration driver
+Parsing input file Miehe71.xinp
+Parsing <geometry>
+Parsing <cahnhilliard>
+Parsing <phasefield>
+Parsing <poroelasticity>
+Parsing <elasticity>
+Parsing <discretization>
+Parsing <newmarksolver>
+Parsing <timestepping>
+Parsing input file succeeded.
+10. Preprocessing the finite element model:
+11. Elasticity solver
+Problem definition:
+Elasticity: 2D, gravity = 0 0
+LinIsotropic: E = 254.8, nu = 0.3, rho = 700, alpha = 1.2e-07
+	Degrading of tensile strain energy density.
+Resolving Dirichlet boundary conditions
+	Constraining P1 E3 in direction(s) 2
+	Constraining P1 E4 in direction(s) 2
+	Constraining P1 E1 in direction(s) 1
+	Constraining P1 E2 in direction(s) 1 code = 1000001
+ >>> SAM model summary <<<
+Number of elements    400
+Number of nodes       441
+Number of dofs        882
+Number of constraints 21
+Number of unknowns    798
+100. Starting the simulation
+  Solving the elasto-dynamics problem...
+  step=1  time=1
+  Primary solution summary: L2-norm         : 0.123996
+                            Max X-component : 0.3
+  Total reaction forces:          Sum(R) : -1029 0
+  displacement\*reactions:          (R,u) : -308.7
+  Elastic strain energy:           eps_e : 15.435
+  Bulk energy:                     eps_b : 15.435
+  Tensile & compressive energies         : 15.435
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -12.4238
+  Solving the elasto-dynamics problem...
+  step=2  time=2
+  Primary solution summary: L2-norm         : 0.247992
+                            Max X-component : 0.6
+  Total reaction forces:          Sum(R) : -2058 0
+  displacement\*reactions:          (R,u) : -1234.8
+  Elastic strain energy:           eps_e : 61.74
+  Bulk energy:                     eps_b : 61.74
+  Tensile & compressive energies         : 61.74
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -24.8475
+  Solving the elasto-dynamics problem...
+  step=3  time=3
+  Primary solution summary: L2-norm         : 0.371988
+                            Max X-component : 0.9
+  Total reaction forces:          Sum(R) : -3087 0
+  displacement\*reactions:          (R,u) : -2778.3
+  Elastic strain energy:           eps_e : 138.915
+  Bulk energy:                     eps_b : 138.915
+  Tensile & compressive energies         : 138.915
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -37.2713
+  Solving the elasto-dynamics problem...
+  step=4  time=4
+  Primary solution summary: L2-norm         : 0.495984
+                            Max X-component : 1.2
+  Total reaction forces:          Sum(R) : -4116 0
+  displacement\*reactions:          (R,u) : -4939.2
+  Elastic strain energy:           eps_e : 246.96
+  Bulk energy:                     eps_b : 246.96
+  Tensile & compressive energies         : 246.96
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -49.6951
+  Solving the elasto-dynamics problem...
+  step=5  time=5
+  Primary solution summary: L2-norm         : 0.61998
+                            Max X-component : 1.5
+  Total reaction forces:          Sum(R) : -5145 0
+  displacement\*reactions:          (R,u) : -7717.5
+  Elastic strain energy:           eps_e : 385.875
+  Bulk energy:                     eps_b : 385.875
+  Tensile & compressive energies         : 385.875
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -62.1188
+  Solving the elasto-dynamics problem...
+  step=6  time=6
+  Primary solution summary: L2-norm         : 0.743976
+                            Max X-component : 1.8
+  Total reaction forces:          Sum(R) : -6174 0
+  displacement\*reactions:          (R,u) : -11113.2
+  Elastic strain energy:           eps_e : 555.66
+  Bulk energy:                     eps_b : 555.66
+  Tensile & compressive energies         : 555.66
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -74.5426
+  Solving the elasto-dynamics problem...
+  step=7  time=7
+  Primary solution summary: L2-norm         : 0.867972
+                            Max X-component : 2.1
+  Total reaction forces:          Sum(R) : -7203 0
+  displacement\*reactions:          (R,u) : -15126.3
+  Elastic strain energy:           eps_e : 756.315
+  Bulk energy:                     eps_b : 756.315
+  Tensile & compressive energies         : 756.315
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -86.9664
+  Solving the elasto-dynamics problem...
+  step=8  time=8
+  Primary solution summary: L2-norm         : 0.991968
+                            Max X-component : 2.4
+  Total reaction forces:          Sum(R) : -8232 0
+  displacement\*reactions:          (R,u) : -19756.8
+  Elastic strain energy:           eps_e : 987.84
+  Bulk energy:                     eps_b : 987.84
+  Tensile & compressive energies         : 987.84
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -99.3901
+  Solving the elasto-dynamics problem...
+  step=9  time=9
+  Primary solution summary: L2-norm         : 1.11596
+                            Max X-component : 2.7
+  Total reaction forces:          Sum(R) : -9261 0
+  displacement\*reactions:          (R,u) : -25004.7
+  Elastic strain energy:           eps_e : 1250.23
+  Bulk energy:                     eps_b : 1250.23
+  Tensile & compressive energies         : 1250.23
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -111.814
+  Solving the elasto-dynamics problem...
+  step=10  time=10
+  Primary solution summary: L2-norm         : 1.23996
+                            Max X-component : 3
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Elastic strain energy:           eps_e : 1543.5
+  Bulk energy:                     eps_b : 1543.5
+  Tensile & compressive energies         : 1543.5
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -124.238
+  Solving the elasto-dynamics problem...
+  step=11  time=20
+  Primary solution summary: L2-norm         : 1.23996
+                            Max X-component : 3
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Elastic strain energy:           eps_e : 1543.5
+  Bulk energy:                     eps_b : 1543.5
+  Tensile & compressive energies         : 1543.5
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -124.238
+  Solving the elasto-dynamics problem...
+  step=12  time=30
+  Primary solution summary: L2-norm         : 1.23996
+                            Max X-component : 3
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Elastic strain energy:           eps_e : 1543.5
+  Bulk energy:                     eps_b : 1543.5
+  Tensile & compressive energies         : 1543.5
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -124.238
+  Solving the elasto-dynamics problem...
+  step=13  time=40
+  Primary solution summary: L2-norm         : 1.23996
+                            Max X-component : 3
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Elastic strain energy:           eps_e : 1543.5
+  Bulk energy:                     eps_b : 1543.5
+  Tensile & compressive energies         : 1543.5
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -124.238
+  Solving the elasto-dynamics problem...
+  step=14  time=50
+  Primary solution summary: L2-norm         : 1.23996
+                            Max X-component : 3
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Elastic strain energy:           eps_e : 1543.5
+  Bulk energy:                     eps_b : 1543.5
+  Tensile & compressive energies         : 1543.5
+  External energy: ((f,u^h)+(t,u^h))^0.5 : -124.238
+  Time integration completed.

--- a/Test/Miehe71-lstatic_FDporo.reg
+++ b/Test/Miehe71-lstatic_FDporo.reg
@@ -1,0 +1,178 @@
+Miehe71.xinp -lstatic -nocrack -poro -stopTime 50
+
+Input file: Miehe71.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Simulation stop time: 50
+0. Parsing input file(s).
+1. Poroelasticity solver
+Parsing input file Miehe71.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]^2
+	Length in X = 5
+	Length in Y = 5
+  Parsing <refine>
+  Parsing <topologysets>
+	Topology sets: Left (1,1,1D)
+	               Right (1,2,1D)
+	               TopBottom (1,3,1D) (1,4,1D)
+  Parsing <refine>
+	Refining P1 19 19
+  Parsing <topologysets>
+Parsing <cahnhilliard>
+Parsing <phasefield>
+Parsing <poroelasticity>
+  Parsing <isotropic>
+	Material code 0: Poroelastic material, see "Problem definition:" below.
+  Parsing <dirichlet>
+	Dirichlet code 2: (fixed)
+  Parsing <dirichlet>
+	Dirichlet code 1: (fixed)
+  Parsing <dirichlet>
+	Dirichlet code 1000001 (ramp): 3 \* Ramp(t,10)
+Parsing <elasticity>
+Parsing <newmarksolver>
+Parsing <timestepping>
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 2
+2. Time integration driver
+Parsing input file Miehe71.xinp
+Parsing <geometry>
+Parsing <cahnhilliard>
+Parsing <phasefield>
+Parsing <poroelasticity>
+Parsing <elasticity>
+Parsing <discretization>
+Parsing <newmarksolver>
+Parsing <timestepping>
+Parsing input file succeeded.
+10. Preprocessing the finite element model:
+11. Poroelasticity solver
+Problem definition:
+PoroElasticity: scaling = 0 useDynCoupling = false
+Elasticity: 2D, gravity = 0 9.81
+	Constitutive Properties:
+		Young's Modulus, E = 254.8
+		Poisson's Ratio, nu = 0.3
+	Densities:
+		Density of Fluid, rhof = 1000
+		Density of Solid, rhos = 666.67
+	Bulk Moduli:
+		Biot's coefficient, alpha = 1
+		Biot's inverse modulus, M^-1 = 0.01
+	Porosity, n = 0.1
+	Permeability, K = 2.07e-09 2.07e-09 0
+Resolving Dirichlet boundary conditions
+	Constraining P1 E3 in direction(s) 2
+	Constraining P1 E4 in direction(s) 2
+	Constraining P1 E1 in direction(s) 1
+	Constraining P1 E2 in direction(s) 1 code = 1000001
+ >>> SAM model summary <<<
+Number of elements    400
+Number of nodes       441
+Number of dofs        1323
+Number of constraints 21
+Number of unknowns    1239
+PoroElasticity: Computed scaling = 3.47495e+07
+100. Starting the simulation
+  Solving the elasto-dynamics problem...
+  step=1  time=1
+  Primary solution summary: L2-norm            : 0.101242
+                            Max X-displacement : 0.3
+                            Max pressure       : 1.72664e-07
+  Total reaction forces:          Sum(R) : -1029 0
+  displacement\*reactions:          (R,u) : -308.7
+  Solving the elasto-dynamics problem...
+  step=2  time=2
+  Primary solution summary: L2-norm            : 0.202485
+                            Max X-displacement : 0.6
+                            Max pressure       : 3.45328e-07
+  Total reaction forces:          Sum(R) : -2058 0
+  displacement\*reactions:          (R,u) : -1234.8
+  Solving the elasto-dynamics problem...
+  step=3  time=3
+  Primary solution summary: L2-norm            : 0.303727
+                            Max X-displacement : 0.9
+                            Max pressure       : 5.17992e-07
+  Total reaction forces:          Sum(R) : -3087 0
+  displacement\*reactions:          (R,u) : -2778.3
+  Solving the elasto-dynamics problem...
+  step=4  time=4
+  Primary solution summary: L2-norm            : 0.404969
+                            Max X-displacement : 1.2
+                            Max pressure       : 6.90657e-07
+  Total reaction forces:          Sum(R) : -4116 0
+  displacement\*reactions:          (R,u) : -4939.2
+  Solving the elasto-dynamics problem...
+  step=5  time=5
+  Primary solution summary: L2-norm            : 0.506211
+                            Max X-displacement : 1.5
+                            Max pressure       : 8.63321e-07
+  Total reaction forces:          Sum(R) : -5145 0
+  displacement\*reactions:          (R,u) : -7717.5
+  Solving the elasto-dynamics problem...
+  step=6  time=6
+  Primary solution summary: L2-norm            : 0.607454
+                            Max X-displacement : 1.8
+                            Max pressure       : 1.03598e-06
+  Total reaction forces:          Sum(R) : -6174 0
+  displacement\*reactions:          (R,u) : -11113.2
+  Solving the elasto-dynamics problem...
+  step=7  time=7
+  Primary solution summary: L2-norm            : 0.708696
+                            Max X-displacement : 2.1
+                            Max pressure       : 1.20865e-06
+  Total reaction forces:          Sum(R) : -7203 0
+  displacement\*reactions:          (R,u) : -15126.3
+  Solving the elasto-dynamics problem...
+  step=8  time=8
+  Primary solution summary: L2-norm            : 0.809938
+                            Max X-displacement : 2.4
+                            Max pressure       : 1.38131e-06
+  Total reaction forces:          Sum(R) : -8232 0
+  displacement\*reactions:          (R,u) : -19756.8
+  Solving the elasto-dynamics problem...
+  step=9  time=9
+  Primary solution summary: L2-norm            : 0.911181
+                            Max X-displacement : 2.7
+                            Max pressure       : 1.55398e-06
+  Total reaction forces:          Sum(R) : -9261 0
+  displacement\*reactions:          (R,u) : -25004.7
+  Solving the elasto-dynamics problem...
+  step=10  time=10
+  Primary solution summary: L2-norm            : 1.01242
+                            Max X-displacement : 3
+                            Max pressure       : 1.72664e-06
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Solving the elasto-dynamics problem...
+  step=11  time=20
+  Primary solution summary: L2-norm            : 1.01242
+                            Max X-displacement : 3
+                            Max pressure       : 1.72664e-06
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Solving the elasto-dynamics problem...
+  step=12  time=30
+  Primary solution summary: L2-norm            : 1.01242
+                            Max X-displacement : 3
+                            Max pressure       : 1.72664e-06
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Solving the elasto-dynamics problem...
+  step=13  time=40
+  Primary solution summary: L2-norm            : 1.01242
+                            Max X-displacement : 3
+                            Max pressure       : 1.72664e-06
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Solving the elasto-dynamics problem...
+  step=14  time=50
+  Primary solution summary: L2-norm            : 1.01242
+                            Max X-displacement : 3
+                            Max pressure       : 1.72664e-06
+  Total reaction forces:          Sum(R) : -10290 0
+  displacement\*reactions:          (R,u) : -30870
+  Time integration completed.

--- a/main_FractureDynamics.C
+++ b/main_FractureDynamics.C
@@ -328,10 +328,7 @@ class LinSIM : public NonLinSIM
 {
 public:
   //! \brief The constructor forwards to the parent class constructor.
-  explicit LinSIM(SIMbase& sim) : NonLinSIM(sim,NonLinSIM::NONE)
-  {
-    fromIni = false;
-  }
+  explicit LinSIM(SIMbase& sim) : NonLinSIM(sim,NonLinSIM::NONE) {}
   //! \brief Empty destructor.
   virtual ~LinSIM() {}
 };
@@ -346,6 +343,12 @@ int runSimulator (const FractureArgs& args)
 {
   switch (args.integrator) {
   case 0:
+    if (args.coupling > 0)
+    {
+      std::cerr <<" *** The linear static option is for non-cracking material"
+                <<" only."<< std::endl;;
+      return 98;
+    }
     return runSimulator4<Dim,LinSIM>(args,"staticsolver");
   case 1:
     return runSimulator1<Dim,NewmarkSIM>(args);


### PR DESCRIPTION
Added: Bail out if -lstatic is used without -nocrack.
Added: Two regression tests using -lstatic.

This is a resolution to the issue pointed out on Skype 3 days ago; the solution is not computed incrementally with the -lstatic option. The simple fix is just to remove the fromIni = false; statement. Then we don't need to touch NonLinSIM. Does not remember any longer why this one was added back in time.