### PR TITLE
have to clear out node numbers

### DIFF
--- a/SIMPhaseField.h
+++ b/SIMPhaseField.h
@@ -589,10 +589,12 @@ protected:
     // Perform initial refinement around the crack (single-patch only)
     RealFunc* refC = chp->initCrack();
     ASMunstruct* patch1 = dynamic_cast<ASMunstruct*>(this->getPatch(1));
-    if (refC && patch1 && this->getNoPatches() == 1)
+    if (refC && patch1 && this->getNoPatches() == 1) {
       for (int i = 0; i < irefine; i++, refTol *= 0.5)
         if (!patch1->refine(*refC,refTol))
           return false;
+      this->getPatch(1)->setGlobalNodeNums(IntVec());
+    }
 
     return result;
   }

--- a/main_FractureDynamics.C
+++ b/main_FractureDynamics.C
@@ -105,6 +105,8 @@ int runCombined (char* infile, double stopTime, const char* context)
   if (!readModel(phaseSim,infile))
     return 1;
 
+  elastoSim.getPatch(1)->clear(true);
+
   phaseSim.opt.print(IFEM::cout) << std::endl;
 
   SIMFractureDynamics frac(elastoSim,phaseSim,infile);


### PR DESCRIPTION
the phase field calls generateFEMtoplogy on the elastosim
in its constructor.

it then performs refinements, which means the MLGN array
in the elastosim is invalid. we need to clear this out.