### PR TITLE
fixed: reorder if to avoid use before initialization

### DIFF
--- a/SIMFractureQstatic.h
+++ b/SIMFractureQstatic.h
@@ -110,7 +110,7 @@ public:
       return SIM::CONVERGED;
 
     static int numIncr = 0;
-    if (conv <= lastConv || tp.iter == 0)
+    if (tp.iter == 0 || conv <= lastConv)
       numIncr = 0;
     else
       numIncr++;


### PR DESCRIPTION
lastConv is not yet inited for iter 0 in first time step.

discovered by the memcheck job, http://afem:8080/job/IFEM-memcheck/181/artifact/serial/build-IFEM-OpenFrac/failed.log/*view*/