### PR TITLE
Changed: SIMElasticity::getIntegrand() now returns an ElasticBase pointer

### DIFF
--- a/SIMDynElasticity.C
+++ b/SIMDynElasticity.C
@@ -337,11 +337,12 @@ deSerialize(const SIMsolution::SerializeMap& data)
 
 
 template< class Dim, class DynSIM, class Sim>
-Elasticity* SIMDynElasticity<Dim,DynSIM,Sim>::getIntegrand ()
+ElasticBase* SIMDynElasticity<Dim,DynSIM,Sim>::getIntegrand ()
 {
   if (!Dim::myProblem) // Using the Voigt formulation by default
     Dim::myProblem = new FractureElasticityVoigt(Dim::dimension);
-  return static_cast<Elasticity*>(Dim::myProblem);
+
+  return static_cast<ElasticBase*>(Dim::myProblem);
 }
 
 

--- a/SIMDynElasticity.h
+++ b/SIMDynElasticity.h
@@ -16,8 +16,7 @@
 
 #include "NonLinSIM.h"
 
-
-class Elasticity;
+class ElasticBase;
 class RealFunc;
 namespace tinyxml2 { class XMLElement; }
 
@@ -125,7 +124,7 @@ public:
 
 protected:
   //! \brief Returns the actual integrand.
-  Elasticity* getIntegrand() override;
+  ElasticBase* getIntegrand() override;
 
   using Sim::parse;
   //! \brief Parses a data section from an XML element.


### PR DESCRIPTION
Downstream of OPM/IFEM-Elasticity#159