### PR TITLE
Changed: bool return value for virtual method printProblem().

### DIFF
--- a/SIMDynElasticity.C
+++ b/SIMDynElasticity.C
@@ -54,21 +54,22 @@ SIMDynElasticity (const std::vector<unsigned char>& nf)
 
 
 template< class Dim, class DynSIM, class Sim>
-void SIMDynElasticity<Dim,DynSIM,Sim>::printProblem () const
+bool SIMDynElasticity<Dim,DynSIM,Sim>::printProblem () const
 {
   static short int ncall = 0;
+  bool prn = true;
   if (++ncall == 1) // Avoiding infinite recursive calls
     dSim.printProblem();
   else
-    this->Sim::printProblem();
+    prn = this->Sim::printProblem();
   --ncall;
+  return prn;
 }
 
 
 template< class Dim, class DynSIM, class Sim>
 bool SIMDynElasticity<Dim,DynSIM,Sim>::init (const TimeStep& tp, bool)
 {
-  dSim.initPrm();
   dSim.initSol(dynamic_cast<NewmarkSIM*>(&dSim) ? 3 : 2);
 
   bool ok = this->setMode(SIM::INIT) && this->getIntegrand()->init(tp.time);

--- a/SIMDynElasticity.h
+++ b/SIMDynElasticity.h
@@ -55,7 +55,10 @@ public:
   virtual ~SIMDynElasticity() {}
 
   //! \brief Prints out problem-specific data to the log stream.
-  void printProblem() const override;
+  bool printProblem() const override;
+
+  //! \brief Initializes time integration parameters for the integrand.
+  void initPrm() { dSim.initPrm(); }
 
   //! \brief Initializes the problem.
   bool init(const TimeStep& tp, bool = false) override;

--- a/main_FractureDynamics.C
+++ b/main_FractureDynamics.C
@@ -126,6 +126,7 @@ int runCombined (char* infile, double stopTime, const char* context)
              <<"\n==========================================="<< std::endl;
 
   // Preprocess the model and establish data structures for the algebraic system
+  elastoSim.initPrm();
   if (!frac.preprocess())
     return 2;
 


### PR DESCRIPTION
Added: Method SIMDynElasticity::initPrm() such that time integration parameters can be initialized before printing problem definition.

Downstreams of OPM/IFEM#753