### PR TITLE
Remove "Primary solution summary:" prefix for phase-field output

### DIFF
--- a/SIMPhaseField.C
+++ b/SIMPhaseField.C
@@ -373,10 +373,8 @@ void SIMPhaseField<Dim>::printSolutionSummary (const Vector& solvec,
   }
 
   std::streamsize oldPrec = prec > 0 ? IFEM::cout.precision(prec) : 0;
-  IFEM::cout <<"                            Min value    : "
-             << minVal <<" node "<< minNod
-             <<"\n                            Range        : "
-             << maxVal-minVal << std::endl;
+  IFEM::cout <<"  Min value          : "<< minVal <<" node "<< minNod
+             <<"\n  Range              : "<< maxVal-minVal << std::endl;
   if (oldPrec > 0) IFEM::cout.precision(oldPrec);
 }
 

--- a/Test/MPI/Short10x20-p1-adap-restart.reg
+++ b/Test/MPI/Short10x20-p1-adap-restart.reg
@@ -50,10 +50,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 13.3075 0.00187632
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.393992
   Solving crack phase field at step=76 time=3.8e-05
-  Primary solution summary: L2-norm      : 0.83704
-                            Max value    : 0.987356
-                            Min value    : -0.00770191
-                            Range        : 1.0077
+  L2-norm            : 0.83704
+  Max value          : 0.987356
+  Min value          : -0.00770191
+  Range              : 1.0077
   Dissipated energy:               eps_d : 0.0954224
   step=77  time=3.85e-05
   Displacement L2-norm            : 3.79241e-06
@@ -70,10 +70,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 14.0909 0.0018477
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.401259
   Solving crack phase field at step=77 time=3.85e-05
-  Primary solution summary: L2-norm      : 0.835702
-                            Max value    : 0.987356
-                            Min value    : -0.00708586
-                            Range        : 1.00709
+  L2-norm            : 0.835702
+  Max value          : 0.987356
+  Min value          : -0.00708586
+  Range              : 1.00709
   Dissipated energy:               eps_d : 0.096935
   >>> Paused for mesh refinement at time=3.85e-05
   Lowest element:  .* |c| = 0.000341245
@@ -97,10 +97,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 14.9055 0.00185419
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.40837
   Solving crack phase field at step=78 time=3.9e-05
-  Primary solution summary: L2-norm      : 0.83434
-                            Max value    : 0.987356
-                            Min value    : -0.00656938
-                            Range        : 1.00657
+  L2-norm            : 0.83434
+  Max value          : 0.987356
+  Min value          : -0.00656938
+  Range              : 1.00657
   Dissipated energy:               eps_d : 0.0985404
   step=79  time=3.95e-05
   Displacement L2-norm            : 3.99533e-06
@@ -117,10 +117,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 15.7617 0.00188281
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.415339
   Solving crack phase field at step=79 time=3.95e-05
-  Primary solution summary: L2-norm      : 0.832971
-                            Max value    : 0.987356
-                            Min value    : -0.00611408
-                            Range        : 1.00611
+  L2-norm            : 0.832971
+  Max value          : 0.987356
+  Min value          : -0.00611408
+  Range              : 1.00611
   Dissipated energy:               eps_d : 0.100062
   >>> Paused for mesh refinement at time=3.95e-05
   Lowest element:  .* |c| = 0.000303939
@@ -143,9 +143,9 @@ Number of unknowns    330
   Tensile & compressive energies         : 16.6735 0.00171962
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.422197
   Solving crack phase field at step=80 time=4e-05
-  Primary solution summary: L2-norm      : 0.831624
-                            Max value    : 0.987355
-                            Min value    : -0.00570466
-                            Range        : 1.0057
+  L2-norm            : 0.831624
+  Max value          : 0.987355
+  Min value          : -0.00570466
+  Range              : 1.0057
   Dissipated energy:               eps_d : 0.10161
   Time integration completed.

--- a/Test/Miehe71_FD.reg
+++ b/Test/Miehe71_FD.reg
@@ -113,10 +113,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15.435
   External energy: ((f,u^h)+(t,u^h))^0.5 : -3.92874
   Solving crack phase field at step=1 time=1
-  Primary solution summary: L2-norm      : 0.749993
-                            Max value    : 0.80195
-                            Min value    : -0.125837
-                            Range        : 1.12584
+  L2-norm            : 0.749993
+  Max value          : 0.80195
+  Min value          : -0.125837
+  Range              : 1.12584
   Dissipated energy:               eps_d : 9.21268
   L1-norm: |c^h| = (|c^h|)        : 17.9004
   Normalized L1-norm: |c^h|/V     : 0.716017
@@ -131,10 +131,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 172.847
   External energy: ((f,u^h)+(t,u^h))^0.5 : -6.39996
   Solving crack phase field at step=2 time=2
-  Primary solution summary: L2-norm      : 0.712248
-                            Max value    : 0.79706
-                            Min value    : -0.028883
-                            Range        : 1.02888
+  L2-norm            : 0.712248
+  Max value          : 0.79706
+  Min value          : -0.028883
+  Range              : 1.02888
   Dissipated energy:               eps_d : 12.1754
   L1-norm: |c^h| = (|c^h|)        : 16.4857
   Normalized L1-norm: |c^h|/V     : 0.659428
@@ -149,10 +149,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 1201.4
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.25648
   Solving crack phase field at step=3 time=3
-  Primary solution summary: L2-norm      : 0.709708
-                            Max value    : 0.79706
-                            Min value    : -0.003712
-                            Range        : 1.00371
+  L2-norm            : 0.709708
+  Max value          : 0.79706
+  Min value          : -0.003712
+  Range              : 1.00371
   Dissipated energy:               eps_d : 13.4453
   L1-norm: |c^h| = (|c^h|)        : 16.2243
   Normalized L1-norm: |c^h|/V     : 0.648973
@@ -167,10 +167,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 2457.94
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.37088
   Solving crack phase field at step=4 time=4
-  Primary solution summary: L2-norm      : 0.709526
-                            Max value    : 0.79706
-                            Min value    : -0.001158
-                            Range        : 1.00116
+  L2-norm            : 0.709526
+  Max value          : 0.79706
+  Min value          : -0.001158
+  Range              : 1.00116
   Dissipated energy:               eps_d : 13.5885
   L1-norm: |c^h| = (|c^h|)        : 16.1978
   Normalized L1-norm: |c^h|/V     : 0.647912
@@ -185,10 +185,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 3854.06
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.37743
   Solving crack phase field at step=5 time=5
-  Primary solution summary: L2-norm      : 0.709465
-                            Max value    : 0.79706
-                            Min value    : -0.000588
-                            Range        : 1.00059
+  L2-norm            : 0.709465
+  Max value          : 0.79706
+  Min value          : -0.000588
+  Range              : 1.00059
   Dissipated energy:               eps_d : 13.6409
   L1-norm: |c^h| = (|c^h|)        : 16.1882
   Normalized L1-norm: |c^h|/V     : 0.647527
@@ -203,10 +203,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 5553.78
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38057
   Solving crack phase field at step=6 time=6
-  Primary solution summary: L2-norm      : 0.709434
-                            Max value    : 0.79706
-                            Min value    : -0.000421
-                            Range        : 1.00042
+  L2-norm            : 0.709434
+  Max value          : 0.79706
+  Min value          : -0.000421
+  Range              : 1.00042
   Dissipated energy:               eps_d : 13.6699
   L1-norm: |c^h| = (|c^h|)        : 16.1829
   Normalized L1-norm: |c^h|/V     : 0.647315
@@ -221,10 +221,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 7561.28
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38223
   Solving crack phase field at step=7 time=7
-  Primary solution summary: L2-norm      : 0.709415
-                            Max value    : 0.79706
-                            Min value    : -0.000315
-                            Range        : 1.00032
+  L2-norm            : 0.709415
+  Max value          : 0.79706
+  Min value          : -0.000315
+  Range              : 1.00032
   Dissipated energy:               eps_d : 13.6875
   L1-norm: |c^h| = (|c^h|)        : 16.1797
   Normalized L1-norm: |c^h|/V     : 0.647186
@@ -239,10 +239,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 9877.08
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38321
   Solving crack phase field at step=8 time=8
-  Primary solution summary: L2-norm      : 0.709403
-                            Max value    : 0.79706
-                            Min value    : -0.000244
-                            Range        : 1.00024
+  L2-norm            : 0.709403
+  Max value          : 0.79706
+  Min value          : -0.000244
+  Range              : 1.00024
   Dissipated energy:               eps_d : 13.699
   L1-norm: |c^h| = (|c^h|)        : 16.1776
   Normalized L1-norm: |c^h|/V     : 0.647102
@@ -257,10 +257,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 12501.4
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38383
   Solving crack phase field at step=9 time=9
-  Primary solution summary: L2-norm      : 0.709394
-                            Max value    : 0.79706
-                            Min value    : -0.000195
-                            Range        : 1.0002
+  L2-norm            : 0.709394
+  Max value          : 0.79706
+  Min value          : -0.000195
+  Range              : 1.0002
   Dissipated energy:               eps_d : 13.7069
   L1-norm: |c^h| = (|c^h|)        : 16.1761
   Normalized L1-norm: |c^h|/V     : 0.647045
@@ -275,10 +275,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.2
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=10 time=10
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003
@@ -293,10 +293,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=11 time=20
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003
@@ -311,10 +311,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=12 time=30
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003
@@ -329,10 +329,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=13 time=40
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003
@@ -347,10 +347,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=14 time=50
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003

--- a/Test/Miehe71_restart.reg
+++ b/Test/Miehe71_restart.reg
@@ -120,10 +120,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=12 time=30
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003
@@ -138,10 +138,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=13 time=40
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003
@@ -156,10 +156,10 @@ Number of unknowns    441
   Tensile & compressive energies         : 15434.5
   External energy: ((f,u^h)+(t,u^h))^0.5 : -7.38426
   Solving crack phase field at step=14 time=50
-  Primary solution summary: L2-norm      : 0.709388
-                            Max value    : 0.79706
-                            Min value    : -0.000159
-                            Range        : 1.00016
+  L2-norm            : 0.709388
+  Max value          : 0.79706
+  Min value          : -0.000159
+  Range              : 1.00016
   Dissipated energy:               eps_d : 13.7125
   L1-norm: |c^h| = (|c^h|)        : 16.1751
   Normalized L1-norm: |c^h|/V     : 0.647003

--- a/Test/Miehe71_restart_poro.reg
+++ b/Test/Miehe71_restart_poro.reg
@@ -135,10 +135,10 @@ Number of unknowns    441
   Total reaction forces:          Sum(R) : -90.79 0
   displacement\*reactions:          (R,u) : -1362.92
   Solving crack phase field at step=12 time=30
-  Primary solution summary: L2-norm      : 0.0171947
-                            Max value    : 0.0274425
-                            Min value    : -0.00416573
-                            Range        : 1.00417
+  L2-norm            : 0.0171947
+  Max value          : 0.0274425
+  Min value          : -0.00416573
+  Range              : 1.00417
   Dissipated energy:               eps_d : 60.5099
   L1-norm: |c^h| = (|c^h|)        : 0.402407
   Normalized L1-norm: |c^h|/V     : 0.0160963
@@ -153,10 +153,10 @@ Number of unknowns    441
   Total reaction forces:          Sum(R) : -328.756 0
   displacement\*reactions:          (R,u) : -991.373
   Solving crack phase field at step=13 time=40
-  Primary solution summary: L2-norm      : 0.0153291
-                            Max value    : 0.0251258
-                            Min value    : -0.00369284
-                            Range        : 1.00369
+  L2-norm            : 0.0153291
+  Max value          : 0.0251258
+  Min value          : -0.00369284
+  Range              : 1.00369
   Dissipated energy:               eps_d : 60.7202
   L1-norm: |c^h| = (|c^h|)        : 0.359453
   Normalized L1-norm: |c^h|/V     : 0.0143781
@@ -171,10 +171,10 @@ Number of unknowns    441
   Total reaction forces:          Sum(R) : 10.6443 0
   displacement\*reactions:          (R,u) : -1170.33
   Solving crack phase field at step=14 time=50
-  Primary solution summary: L2-norm      : 0.0153291
-                            Max value    : 0.0251258
-                            Min value    : -0.00369284
-                            Range        : 1.00369
+  L2-norm            : 0.0153291
+  Max value          : 0.0251258
+  Min value          : -0.00369284
+  Range              : 1.00369
   Dissipated energy:               eps_d : 60.7202
   L1-norm: |c^h| = (|c^h|)        : 0.359453
   Normalized L1-norm: |c^h|/V     : 0.0143781

--- a/Test/Short10x20-adap_FD.reg
+++ b/Test/Short10x20-adap_FD.reg
@@ -93,10 +93,10 @@ Number of nodes       231
 Number of dofs        231
 Number of unknowns    231
   Solving crack phase field at step=0 time=0
-  Primary solution summary: L2-norm      : 0.943323
-                            Max value    : 0.999976
-                            Min value    : -0.177109
-                            Range        : 1.17711
+  L2-norm            : 0.943323
+  Max value          : 0.999976
+  Min value          : -0.177109
+  Range              : 1.17711
   Dissipated energy:               eps_d : 0.0501758
   Lowest element:      ...    |c| = 0.00299945
   Highest element:     ...    |c| = 0.999964
@@ -134,10 +134,10 @@ Number of dofs        308
 Number of unknowns    308
   Solving crack phase field at step=0 time=0
  using smearing factor 0.0005
-  Primary solution summary: L2-norm      : 0.929409
-                            Max value    : 1
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.929409
+  Max value          : 1
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0453309
   Lowest element:      ...    |c| = 0.00299941
   Highest element:     ...    |c| = 1
@@ -190,10 +190,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00043578 6.24402e-07
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.0391341
   Solving crack phase field at step=1 time=5e-07
-  Primary solution summary: L2-norm      : 0.929004
-                            Max value    : 1
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.929004
+  Max value          : 1
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.045332
   Solving the elasto-dynamics problem...
   step=2  time=1e-06
@@ -210,10 +210,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00193691 8.68476e-06
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.0640054
   Solving crack phase field at step=2 time=1e-06
-  Primary solution summary: L2-norm      : 0.927703
-                            Max value    : 0.999999
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.927703
+  Max value          : 0.999999
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0453489
   >>> Paused for mesh refinement at time=1e-06
   Lowest element:      ...    |c| = 0.00299941
@@ -236,10 +236,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00288079 2.93127e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.0788237
   Solving crack phase field at step=3 time=1.5e-06
-  Primary solution summary: L2-norm      : 0.926864
-                            Max value    : 0.999998
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.926864
+  Max value          : 0.999998
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0453648
   Solving the elasto-dynamics problem...
   step=4  time=2e-06
@@ -256,10 +256,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00378275 5.74129e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.0908882
   Solving crack phase field at step=4 time=2e-06
-  Primary solution summary: L2-norm      : 0.926072
-                            Max value    : 0.999998
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.926072
+  Max value          : 0.999998
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0453795
   >>> Paused for mesh refinement at time=2e-06
   Lowest element:      ...    |c| = 0.00299941
@@ -282,10 +282,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.004982 9.43879e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.103114
   Solving crack phase field at step=5 time=2.5e-06
-  Primary solution summary: L2-norm      : 0.925189
-                            Max value    : 0.999997
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.925189
+  Max value          : 0.999997
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0453973
   Solving the elasto-dynamics problem...
   step=6  time=3e-06
@@ -302,10 +302,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.006039 0.000144351
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.113537
   Solving crack phase field at step=6 time=3e-06
-  Primary solution summary: L2-norm      : 0.924289
-                            Max value    : 0.999996
-                            Min value    : -0.177123
-                            Range        : 1.17712
+  L2-norm            : 0.924289
+  Max value          : 0.999996
+  Min value          : -0.177123
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0454157
   >>> Paused for mesh refinement at time=3e-06
   Lowest element:      ...    |c| = 0.00299941
@@ -328,10 +328,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00696986 0.00021264
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.122614
   Solving crack phase field at step=7 time=3.5e-06
-  Primary solution summary: L2-norm      : 0.923413
-                            Max value    : 0.999995
-                            Min value    : -0.177122
-                            Range        : 1.17712
+  L2-norm            : 0.923413
+  Max value          : 0.999995
+  Min value          : -0.177122
+  Range              : 1.17712
   Dissipated energy:               eps_d : 0.0454328
   Solving the elasto-dynamics problem...
   step=8  time=4e-06
@@ -348,10 +348,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00803143 0.000309742
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.131662
   Solving crack phase field at step=8 time=4e-06
-  Primary solution summary: L2-norm      : 0.922562
-                            Max value    : 0.999975
-                            Min value    : -0.177113
-                            Range        : 1.17711
+  L2-norm            : 0.922562
+  Max value          : 0.999975
+  Min value          : -0.177113
+  Range              : 1.17711
   Dissipated energy:               eps_d : 0.0454479
   >>> Paused for mesh refinement at time=4e-06
   Lowest element:      ...    |c| = 0.00299931
@@ -375,10 +375,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.00910352 0.000440373
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.140205
   Solving crack phase field at step=9 time=4.5e-06
-  Primary solution summary: L2-norm      : 0.921623
-                            Max value    : 0.999776
-                            Min value    : -0.177059
-                            Range        : 1.17706
+  L2-norm            : 0.921623
+  Max value          : 0.999776
+  Min value          : -0.177059
+  Range              : 1.17706
   Dissipated energy:               eps_d : 0.0454632
   Solving the elasto-dynamics problem...
   step=10  time=5e-06
@@ -396,10 +396,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0101532 0.00060127
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.147963
   Solving crack phase field at step=10 time=5e-06
-  Primary solution summary: L2-norm      : 0.920451
-                            Max value    : 0.998483
-                            Min value    : -0.176816
-                            Range        : 1.17682
+  L2-norm            : 0.920451
+  Max value          : 0.998483
+  Min value          : -0.176816
+  Range              : 1.17682
   Dissipated energy:               eps_d : 0.0454812
   >>> Paused for mesh refinement at time=5e-06
   Lowest element:      ...    |c| = 0.00299736
@@ -423,10 +423,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0118717 0.000784207
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.155511
   Solving crack phase field at step=11 time=5.5e-06
-  Primary solution summary: L2-norm      : 0.919009
-                            Max value    : 0.993066
-                            Min value    : -0.175971
-                            Range        : 1.17597
+  L2-norm            : 0.919009
+  Max value          : 0.993066
+  Min value          : -0.175971
+  Range              : 1.17597
   Dissipated energy:               eps_d : 0.0455092
   Solving the elasto-dynamics problem...
   step=12  time=6e-06
@@ -444,10 +444,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0161688 0.000976605
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.162862
   Solving crack phase field at step=12 time=6e-06
-  Primary solution summary: L2-norm      : 0.917241
-                            Max value    : 0.988749
-                            Min value    : -0.173734
-                            Range        : 1.17373
+  L2-norm            : 0.917241
+  Max value          : 0.988749
+  Min value          : -0.173734
+  Range              : 1.17373
   Dissipated energy:               eps_d : 0.0455773
   >>> Paused for mesh refinement at time=6e-06
   Lowest element:      ...    |c| = 0.00297706
@@ -471,10 +471,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.026309 0.00116319
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.169745
   Solving crack phase field at step=13 time=6.5e-06
-  Primary solution summary: L2-norm      : 0.914908
-                            Max value    : 0.988745
-                            Min value    : -0.169496
-                            Range        : 1.1695
+  L2-norm            : 0.914908
+  Max value          : 0.988745
+  Min value          : -0.169496
+  Range              : 1.1695
   Dissipated energy:               eps_d : 0.0457371
   Solving the elasto-dynamics problem...
   step=14  time=7e-06
@@ -492,10 +492,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0436736 0.00133019
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.17634
   Solving crack phase field at step=14 time=7e-06
-  Primary solution summary: L2-norm      : 0.91223
-                            Max value    : 0.988739
-                            Min value    : -0.164361
-                            Range        : 1.16436
+  L2-norm            : 0.91223
+  Max value          : 0.988739
+  Min value          : -0.164361
+  Range              : 1.16436
   Dissipated energy:               eps_d : 0.0460018
   >>> Paused for mesh refinement at time=7e-06
   Lowest element:      ...    |c| = 0.00280995
@@ -519,10 +519,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0640038 0.0014648
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.182779
   Solving crack phase field at step=15 time=7.5e-06
-  Primary solution summary: L2-norm      : 0.909599
-                            Max value    : 0.988712
-                            Min value    : -0.160902
-                            Range        : 1.1609
+  L2-norm            : 0.909599
+  Max value          : 0.988712
+  Min value          : -0.160902
+  Range              : 1.1609
   Dissipated energy:               eps_d : 0.0463286
   Solving the elasto-dynamics problem...
   step=16  time=8e-06
@@ -540,10 +540,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0818505 0.00156403
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.188943
   Solving crack phase field at step=16 time=8e-06
-  Primary solution summary: L2-norm      : 0.906983
-                            Max value    : 0.988672
-                            Min value    : -0.159547
-                            Range        : 1.15955
+  L2-norm            : 0.906983
+  Max value          : 0.988672
+  Min value          : -0.159547
+  Range              : 1.15955
   Dissipated energy:               eps_d : 0.0466782
   >>> Paused for mesh refinement at time=8e-06
   Lowest element:      ...    |c| = 0.00258142
@@ -567,10 +567,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.0977747 0.00164282
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.194881
   Solving crack phase field at step=17 time=8.5e-06
-  Primary solution summary: L2-norm      : 0.904186
-                            Max value    : 0.988642
-                            Min value    : -0.158197
-                            Range        : 1.1582
+  L2-norm            : 0.904186
+  Max value          : 0.988642
+  Min value          : -0.158197
+  Range              : 1.1582
   Dissipated energy:               eps_d : 0.0470605
   Solving the elasto-dynamics problem...
   step=18  time=9e-06
@@ -588,10 +588,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.116358 0.00170374
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.200741
   Solving crack phase field at step=18 time=9e-06
-  Primary solution summary: L2-norm      : 0.901379
-                            Max value    : 0.988574
-                            Min value    : -0.155362
-                            Range        : 1.15536
+  L2-norm            : 0.901379
+  Max value          : 0.988574
+  Min value          : -0.155362
+  Range              : 1.15536
   Dissipated energy:               eps_d : 0.0475407
   >>> Paused for mesh refinement at time=9e-06
   Lowest element:      ...    |c| = 0.00246352
@@ -615,10 +615,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.140093 0.0017421
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.206514
   Solving crack phase field at step=19 time=9.5e-06
-  Primary solution summary: L2-norm      : 0.898638
-                            Max value    : 0.988422
-                            Min value    : -0.150489
-                            Range        : 1.15049
+  L2-norm            : 0.898638
+  Max value          : 0.988422
+  Min value          : -0.150489
+  Range              : 1.15049
   Dissipated energy:               eps_d : 0.0481416
   Solving the elasto-dynamics problem...
   step=20  time=1e-05
@@ -636,10 +636,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.16719 0.00176103
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.212198
   Solving crack phase field at step=20 time=1e-05
-  Primary solution summary: L2-norm      : 0.895802
-                            Max value    : 0.988059
-                            Min value    : -0.144559
-                            Range        : 1.14456
+  L2-norm            : 0.895802
+  Max value          : 0.988059
+  Min value          : -0.144559
+  Range              : 1.14456
   Dissipated energy:               eps_d : 0.0488367
   >>> Paused for mesh refinement at time=1e-05
   Lowest element:      ...    |c| = 0.00228939
@@ -663,10 +663,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.194721 0.00176282
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.217846
   Solving crack phase field at step=21 time=1.05e-05
-  Primary solution summary: L2-norm      : 0.893105
-                            Max value    : 0.987892
-                            Min value    : -0.139026
-                            Range        : 1.13903
+  L2-norm            : 0.893105
+  Max value          : 0.987892
+  Min value          : -0.139026
+  Range              : 1.13903
   Dissipated energy:               eps_d : 0.0495453
   Solving the elasto-dynamics problem...
   step=22  time=1.1e-05
@@ -684,10 +684,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.222905 0.00173912
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.223375
   Solving crack phase field at step=22 time=1.1e-05
-  Primary solution summary: L2-norm      : 0.890523
-                            Max value    : 0.987878
-                            Min value    : -0.134266
-                            Range        : 1.13427
+  L2-norm            : 0.890523
+  Max value          : 0.987878
+  Min value          : -0.134266
+  Range              : 1.13427
   Dissipated energy:               eps_d : 0.0502809
   >>> Paused for mesh refinement at time=1.1e-05
   Lowest element:      ...    |c| = 0.00207839
@@ -711,10 +711,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.253766 0.00167949
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.228541
   Solving crack phase field at step=23 time=1.15e-05
-  Primary solution summary: L2-norm      : 0.888129
-                            Max value    : 0.987807
-                            Min value    : -0.129965
-                            Range        : 1.12996
+  L2-norm            : 0.888129
+  Max value          : 0.987807
+  Min value          : -0.129965
+  Range              : 1.12996
   Dissipated energy:               eps_d : 0.0510635
   Solving the elasto-dynamics problem...
   step=24  time=1.2e-05
@@ -732,10 +732,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.287833 0.00159422
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.233047
   Solving crack phase field at step=24 time=1.2e-05
-  Primary solution summary: L2-norm      : 0.885971
-                            Max value    : 0.987776
-                            Min value    : -0.125979
-                            Range        : 1.12598
+  L2-norm            : 0.885971
+  Max value          : 0.987776
+  Min value          : -0.125979
+  Range              : 1.12598
   Dissipated energy:               eps_d : 0.0518867
   >>> Paused for mesh refinement at time=1.2e-05
   Lowest element:      ...    |c| = 0.00189721
@@ -759,10 +759,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.3242 0.00152946
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.236609
   Solving crack phase field at step=25 time=1.25e-05
-  Primary solution summary: L2-norm      : 0.883968
-                            Max value    : 0.987767
-                            Min value    : -0.122206
-                            Range        : 1.12221
+  L2-norm            : 0.883968
+  Max value          : 0.987767
+  Min value          : -0.122206
+  Range              : 1.12221
   Dissipated energy:               eps_d : 0.052729
   Solving the elasto-dynamics problem...
   step=26  time=1.3e-05
@@ -780,10 +780,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.362547 0.0015219
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.239093
   Solving crack phase field at step=26 time=1.3e-05
-  Primary solution summary: L2-norm      : 0.882199
-                            Max value    : 0.987644
-                            Min value    : -0.1186
-                            Range        : 1.1186
+  L2-norm            : 0.882199
+  Max value          : 0.987644
+  Min value          : -0.1186
+  Range              : 1.1186
   Dissipated energy:               eps_d : 0.0535803
   >>> Paused for mesh refinement at time=1.3e-05
   Lowest element:      ...    |c| = 0.0018
@@ -807,10 +807,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.403443 0.00156676
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.240675
   Solving crack phase field at step=27 time=1.35e-05
-  Primary solution summary: L2-norm      : 0.880562
-                            Max value    : 0.987464
-                            Min value    : -0.1152
-                            Range        : 1.1152
+  L2-norm            : 0.880562
+  Max value          : 0.987464
+  Min value          : -0.1152
+  Range              : 1.1152
   Dissipated energy:               eps_d : 0.05444
   Solving the elasto-dynamics problem...
   step=28  time=1.4e-05
@@ -828,10 +828,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.447357 0.0016429
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.241767
   Solving crack phase field at step=28 time=1.4e-05
-  Primary solution summary: L2-norm      : 0.879136
-                            Max value    : 0.987398
-                            Min value    : -0.112063
-                            Range        : 1.11206
+  L2-norm            : 0.879136
+  Max value          : 0.987398
+  Min value          : -0.112063
+  Range              : 1.11206
   Dissipated energy:               eps_d : 0.0552833
   >>> Paused for mesh refinement at time=1.4e-05
   Lowest element:      ...    |c| = 0.00172533
@@ -855,10 +855,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.49461 0.00172522
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.242794
   Solving crack phase field at step=29 time=1.45e-05
-  Primary solution summary: L2-norm      : 0.877934
-                            Max value    : 0.987395
-                            Min value    : -0.109075
-                            Range        : 1.10908
+  L2-norm            : 0.877934
+  Max value          : 0.987395
+  Min value          : -0.109075
+  Range              : 1.10908
   Dissipated energy:               eps_d : 0.0560946
   Solving the elasto-dynamics problem...
   step=30  time=1.5e-05
@@ -876,10 +876,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.545974 0.00179195
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.244004
   Solving crack phase field at step=30 time=1.5e-05
-  Primary solution summary: L2-norm      : 0.876915
-                            Max value    : 0.987392
-                            Min value    : -0.106126
-                            Range        : 1.10613
+  L2-norm            : 0.876915
+  Max value          : 0.987392
+  Min value          : -0.106126
+  Range              : 1.10613
   Dissipated energy:               eps_d : 0.0568693
   >>> Paused for mesh refinement at time=1.5e-05
   Lowest element:      ...    |c| = 0.00162902
@@ -903,10 +903,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.602602 0.00184236
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.245397
   Solving crack phase field at step=31 time=1.55e-05
-  Primary solution summary: L2-norm      : 0.876044
-                            Max value    : 0.98739
-                            Min value    : -0.103214
-                            Range        : 1.10321
+  L2-norm            : 0.876044
+  Max value          : 0.98739
+  Min value          : -0.103214
+  Range              : 1.10321
   Dissipated energy:               eps_d : 0.0576135
   Solving the elasto-dynamics problem...
   step=32  time=1.6e-05
@@ -924,10 +924,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.665449 0.00191173
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.246769
   Solving crack phase field at step=32 time=1.6e-05
-  Primary solution summary: L2-norm      : 0.875307
-                            Max value    : 0.987388
-                            Min value    : -0.100439
-                            Range        : 1.10044
+  L2-norm            : 0.875307
+  Max value          : 0.987388
+  Min value          : -0.100439
+  Range              : 1.10044
   Dissipated energy:               eps_d : 0.0583302
   >>> Paused for mesh refinement at time=1.6e-05
   Lowest element:      ...    |c| = 0.00142375
@@ -951,10 +951,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.73495 0.00203054
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.247899
   Solving crack phase field at step=33 time=1.65e-05
-  Primary solution summary: L2-norm      : 0.874669
-                            Max value    : 0.987386
-                            Min value    : -0.0978692
-                            Range        : 1.09787
+  L2-norm            : 0.874669
+  Max value          : 0.987386
+  Min value          : -0.0978692
+  Range              : 1.09787
   Dissipated energy:               eps_d : 0.0590226
   Solving the elasto-dynamics problem...
   step=34  time=1.7e-05
@@ -972,10 +972,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.810328 0.00216667
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.248723
   Solving crack phase field at step=34 time=1.7e-05
-  Primary solution summary: L2-norm      : 0.874117
-                            Max value    : 0.987384
-                            Min value    : -0.0954936
-                            Range        : 1.09549
+  L2-norm            : 0.874117
+  Max value          : 0.987384
+  Min value          : -0.0954936
+  Range              : 1.09549
   Dissipated energy:               eps_d : 0.0596814
   >>> Paused for mesh refinement at time=1.7e-05
   Lowest element:      ...    |c| = 0.00123841
@@ -999,10 +999,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.888451 0.00223395
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.24935
   Solving crack phase field at step=35 time=1.75e-05
-  Primary solution summary: L2-norm      : 0.873664
-                            Max value    : 0.987383
-                            Min value    : -0.0933517
-                            Range        : 1.09335
+  L2-norm            : 0.873664
+  Max value          : 0.987383
+  Min value          : -0.0933517
+  Range              : 1.09335
   Dissipated energy:               eps_d : 0.0602793
   Solving the elasto-dynamics problem...
   step=36  time=1.8e-05
@@ -1020,10 +1020,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 0.963887 0.00217481
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.24992
   Solving crack phase field at step=36 time=1.8e-05
-  Primary solution summary: L2-norm      : 0.87331
-                            Max value    : 0.987381
-                            Min value    : -0.0915932
-                            Range        : 1.09159
+  L2-norm            : 0.87331
+  Max value          : 0.987381
+  Min value          : -0.0915932
+  Range              : 1.09159
   Dissipated energy:               eps_d : 0.0607857
   >>> Paused for mesh refinement at time=1.8e-05
   Lowest element:      ...    |c| = 0.00112821
@@ -1047,10 +1047,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.03095 0.00201741
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.250477
   Solving crack phase field at step=37 time=1.85e-05
-  Primary solution summary: L2-norm      : 0.873052
-                            Max value    : 0.98738
-                            Min value    : -0.0904599
-                            Range        : 1.09046
+  L2-norm            : 0.873052
+  Max value          : 0.98738
+  Min value          : -0.0904599
+  Range              : 1.09046
   Dissipated energy:               eps_d : 0.0611792
   Solving the elasto-dynamics problem...
   step=38  time=1.9e-05
@@ -1068,10 +1068,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.08668 0.00181587
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.250967
   Solving crack phase field at step=38 time=1.9e-05
-  Primary solution summary: L2-norm      : 0.872865
-                            Max value    : 0.987379
-                            Min value    : -0.0898853
-                            Range        : 1.08989
+  L2-norm            : 0.872865
+  Max value          : 0.987379
+  Min value          : -0.0898853
+  Range              : 1.08989
   Dissipated energy:               eps_d : 0.0614719
   >>> Paused for mesh refinement at time=1.9e-05
   Lowest element:      ...    |c| = 0.00106902
@@ -1095,10 +1095,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.13462 0.00161074
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.251344
   Solving crack phase field at step=39 time=1.95e-05
-  Primary solution summary: L2-norm      : 0.872708
-                            Max value    : 0.987378
-                            Min value    : -0.089614
-                            Range        : 1.08961
+  L2-norm            : 0.872708
+  Max value          : 0.987378
+  Min value          : -0.089614
+  Range              : 1.08961
   Dissipated energy:               eps_d : 0.0617034
   Solving the elasto-dynamics problem...
   step=40  time=2e-05
@@ -1116,10 +1116,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.18483 0.00143166
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.251637
   Solving crack phase field at step=40 time=2e-05
-  Primary solution summary: L2-norm      : 0.872547
-                            Max value    : 0.987378
-                            Min value    : -0.0893635
-                            Range        : 1.08936
+  L2-norm            : 0.872547
+  Max value          : 0.987378
+  Min value          : -0.0893635
+  Range              : 1.08936
   Dissipated energy:               eps_d : 0.0619232
   >>> Paused for mesh refinement at time=2e-05
   Lowest element:      ...    |c| = 0.00100364
@@ -1143,10 +1143,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.24875 0.00128665
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.251911
   Solving crack phase field at step=41 time=2.05e-05
-  Primary solution summary: L2-norm      : 0.872391
-                            Max value    : 0.987377
-                            Min value    : -0.0888993
-                            Range        : 1.0889
+  L2-norm            : 0.872391
+  Max value          : 0.987377
+  Min value          : -0.0888993
+  Range              : 1.0889
   Dissipated energy:               eps_d : 0.0621709
   Solving the elasto-dynamics problem...
   step=42  time=2.1e-05
@@ -1164,10 +1164,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.33356 0.00117909
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.252194
   Solving crack phase field at step=42 time=2.1e-05
-  Primary solution summary: L2-norm      : 0.872181
-                            Max value    : 0.987376
-                            Min value    : -0.0872721
-                            Range        : 1.08727
+  L2-norm            : 0.872181
+  Max value          : 0.987376
+  Min value          : -0.0872721
+  Range              : 1.08727
   Dissipated energy:               eps_d : 0.0625011
   >>> Paused for mesh refinement at time=2.1e-05
   Lowest element:      ...    |c| = 0.000907549
@@ -1191,10 +1191,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.43848 0.00112805
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.252498
   Solving crack phase field at step=43 time=2.15e-05
-  Primary solution summary: L2-norm      : 0.871855
-                            Max value    : 0.987375
-                            Min value    : -0.0845186
-                            Range        : 1.08452
+  L2-norm            : 0.871855
+  Max value          : 0.987375
+  Min value          : -0.0845186
+  Range              : 1.08452
   Dissipated energy:               eps_d : 0.0629408
   Solving the elasto-dynamics problem...
   step=44  time=2.2e-05
@@ -1212,10 +1212,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.55354 0.00116688
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.252864
   Solving crack phase field at step=44 time=2.2e-05
-  Primary solution summary: L2-norm      : 0.871505
-                            Max value    : 0.987374
-                            Min value    : -0.0816105
-                            Range        : 1.08161
+  L2-norm            : 0.871505
+  Max value          : 0.987374
+  Min value          : -0.0816105
+  Range              : 1.08161
   Dissipated energy:               eps_d : 0.0633933
   >>> Paused for mesh refinement at time=2.2e-05
   Lowest element:      ...    |c| = 0.000819117
@@ -1239,10 +1239,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.66312 0.0012786
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.253366
   Solving crack phase field at step=45 time=2.25e-05
-  Primary solution summary: L2-norm      : 0.871194
-                            Max value    : 0.987373
-                            Min value    : -0.0791157
-                            Range        : 1.07912
+  L2-norm            : 0.871194
+  Max value          : 0.987373
+  Min value          : -0.0791157
+  Range              : 1.07912
   Dissipated energy:               eps_d : 0.0637955
   Solving the elasto-dynamics problem...
   step=46  time=2.3e-05
@@ -1260,10 +1260,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.7646 0.00142818
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.254075
   Solving crack phase field at step=46 time=2.3e-05
-  Primary solution summary: L2-norm      : 0.870919
-                            Max value    : 0.987373
-                            Min value    : -0.0771512
-                            Range        : 1.07715
+  L2-norm            : 0.870919
+  Max value          : 0.987373
+  Min value          : -0.0771512
+  Range              : 1.07715
   Dissipated energy:               eps_d : 0.0641489
   >>> Paused for mesh refinement at time=2.3e-05
   Lowest element:      ...    |c| = 0.000773884
@@ -1287,10 +1287,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.86858 0.00166907
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.255056
   Solving crack phase field at step=47 time=2.35e-05
-  Primary solution summary: L2-norm      : 0.870643
-                            Max value    : 0.987372
-                            Min value    : -0.0754128
-                            Range        : 1.07541
+  L2-norm            : 0.870643
+  Max value          : 0.987372
+  Min value          : -0.0754128
+  Range              : 1.07541
   Dissipated energy:               eps_d : 0.0644938
   Solving the elasto-dynamics problem...
   step=48  time=2.4e-05
@@ -1308,10 +1308,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 1.9862 0.00204587
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.25637
   Solving crack phase field at step=48 time=2.4e-05
-  Primary solution summary: L2-norm      : 0.87034
-                            Max value    : 0.987371
-                            Min value    : -0.0736288
-                            Range        : 1.07363
+  L2-norm            : 0.87034
+  Max value          : 0.987371
+  Min value          : -0.0736288
+  Range              : 1.07363
   Dissipated energy:               eps_d : 0.064868
   >>> Paused for mesh refinement at time=2.4e-05
   Lowest element:      ...    |c| = 0.000740564
@@ -1335,10 +1335,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 2.12375 0.00258149
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.25806
   Solving crack phase field at step=49 time=2.45e-05
-  Primary solution summary: L2-norm      : 0.87002
-                            Max value    : 0.98737
-                            Min value    : -0.0715657
-                            Range        : 1.07157
+  L2-norm            : 0.87002
+  Max value          : 0.98737
+  Min value          : -0.0715657
+  Range              : 1.07157
   Dissipated energy:               eps_d : 0.0652842
   Solving the elasto-dynamics problem...
   step=50  time=2.5e-05
@@ -1356,10 +1356,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 2.28127 0.00322809
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.260148
   Solving crack phase field at step=50 time=2.5e-05
-  Primary solution summary: L2-norm      : 0.869688
-                            Max value    : 0.987369
-                            Min value    : -0.0691367
-                            Range        : 1.06914
+  L2-norm            : 0.869688
+  Max value          : 0.987369
+  Min value          : -0.0691367
+  Range              : 1.06914
   Dissipated energy:               eps_d : 0.0657335
   >>> Paused for mesh refinement at time=2.5e-05
   Lowest element:      ...    |c| = 0.000705314
@@ -1383,10 +1383,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 2.45398 0.00387979
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.26265
   Solving crack phase field at step=51 time=2.55e-05
-  Primary solution summary: L2-norm      : 0.869343
-                            Max value    : 0.987368
-                            Min value    : -0.0663452
-                            Range        : 1.06635
+  L2-norm            : 0.869343
+  Max value          : 0.987368
+  Min value          : -0.0663452
+  Range              : 1.06635
   Dissipated energy:               eps_d : 0.0661992
   Solving the elasto-dynamics problem...
   step=52  time=2.6e-05
@@ -1404,10 +1404,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 2.6364 0.00444783
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.265581
   Solving crack phase field at step=52 time=2.6e-05
-  Primary solution summary: L2-norm      : 0.868954
-                            Max value    : 0.987367
-                            Min value    : -0.0632643
-                            Range        : 1.06326
+  L2-norm            : 0.868954
+  Max value          : 0.987367
+  Min value          : -0.0632643
+  Range              : 1.06326
   Dissipated energy:               eps_d : 0.0666748
   >>> Paused for mesh refinement at time=2.6e-05
   Lowest element:      ...    |c| = 0.000671908
@@ -1431,10 +1431,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 2.82419 0.00488517
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.268949
   Solving crack phase field at step=53 time=2.65e-05
-  Primary solution summary: L2-norm      : 0.868489
-                            Max value    : 0.987366
-                            Min value    : -0.0600055
-                            Range        : 1.06001
+  L2-norm            : 0.868489
+  Max value          : 0.987366
+  Min value          : -0.0600055
+  Range              : 1.06001
   Dissipated energy:               eps_d : 0.0671693
   Solving the elasto-dynamics problem...
   step=54  time=2.7e-05
@@ -1452,10 +1452,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 3.01297 0.00518947
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.272713
   Solving crack phase field at step=54 time=2.7e-05
-  Primary solution summary: L2-norm      : 0.867911
-                            Max value    : 0.987365
-                            Min value    : -0.0566663
-                            Range        : 1.05667
+  L2-norm            : 0.867911
+  Max value          : 0.987365
+  Min value          : -0.0566663
+  Range              : 1.05667
   Dissipated energy:               eps_d : 0.0677028
   >>> Paused for mesh refinement at time=2.7e-05
   Lowest element:      ...    |c| = 0.000645436
@@ -1479,10 +1479,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 3.19729 0.00540511
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.276765
   Solving crack phase field at step=55 time=2.75e-05
-  Primary solution summary: L2-norm      : 0.867249
-                            Max value    : 0.987365
-                            Min value    : -0.0533018
-                            Range        : 1.0533
+  L2-norm            : 0.867249
+  Max value          : 0.987365
+  Min value          : -0.0533018
+  Range              : 1.0533
   Dissipated energy:               eps_d : 0.0682842
   Solving the elasto-dynamics problem...
   step=56  time=2.8e-05
@@ -1500,10 +1500,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 3.37662 0.00555358
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.280949
   Solving crack phase field at step=56 time=2.8e-05
-  Primary solution summary: L2-norm      : 0.86652
-                            Max value    : 0.987364
-                            Min value    : -0.0500171
-                            Range        : 1.05002
+  L2-norm            : 0.86652
+  Max value          : 0.987364
+  Min value          : -0.0500171
+  Range              : 1.05002
   Dissipated energy:               eps_d : 0.0689315
   >>> Paused for mesh refinement at time=2.8e-05
   Lowest element:      ...    |c| = 0.000622427
@@ -1527,10 +1527,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 3.55952 0.00566288
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.285144
   Solving crack phase field at step=57 time=2.85e-05
-  Primary solution summary: L2-norm      : 0.865767
-                            Max value    : 0.987364
-                            Min value    : -0.0467588
-                            Range        : 1.04676
+  L2-norm            : 0.865767
+  Max value          : 0.987364
+  Min value          : -0.0467588
+  Range              : 1.04676
   Dissipated energy:               eps_d : 0.0696518
   Solving the elasto-dynamics problem...
   step=58  time=2.9e-05
@@ -1548,10 +1548,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 3.7603 0.00581037
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.289346
   Solving crack phase field at step=58 time=2.9e-05
-  Primary solution summary: L2-norm      : 0.864982
-                            Max value    : 0.987363
-                            Min value    : -0.0432462
-                            Range        : 1.04325
+  L2-norm            : 0.864982
+  Max value          : 0.987363
+  Min value          : -0.0432462
+  Range              : 1.04325
   Dissipated energy:               eps_d : 0.0704714
   >>> Paused for mesh refinement at time=2.9e-05
   Lowest element:      ...    |c| = 0.00059923
@@ -1575,10 +1575,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 3.99447 0.00601181
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.29368
   Solving crack phase field at step=59 time=2.95e-05
-  Primary solution summary: L2-norm      : 0.864209
-                            Max value    : 0.987363
-                            Min value    : -0.0394823
-                            Range        : 1.03948
+  L2-norm            : 0.864209
+  Max value          : 0.987363
+  Min value          : -0.0394823
+  Range              : 1.03948
   Dissipated energy:               eps_d : 0.0713807
   Solving the elasto-dynamics problem...
   step=60  time=3e-05
@@ -1596,10 +1596,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 4.27447 0.00621455
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.298305
   Solving crack phase field at step=60 time=3e-05
-  Primary solution summary: L2-norm      : 0.863413
-                            Max value    : 0.987362
-                            Min value    : -0.0357845
-                            Range        : 1.03578
+  L2-norm            : 0.863413
+  Max value          : 0.987362
+  Min value          : -0.0357845
+  Range              : 1.03578
   Dissipated energy:               eps_d : 0.0723823
   >>> Paused for mesh refinement at time=3e-05
   Lowest element:      ...    |c| = 0.000576552
@@ -1623,10 +1623,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 4.60645 0.00634062
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.303286
   Solving crack phase field at step=61 time=3.05e-05
-  Primary solution summary: L2-norm      : 0.862572
-                            Max value    : 0.987361
-                            Min value    : -0.0325113
-                            Range        : 1.03251
+  L2-norm            : 0.862572
+  Max value          : 0.987361
+  Min value          : -0.0325113
+  Range              : 1.03251
   Dissipated energy:               eps_d : 0.0734624
   Solving the elasto-dynamics problem...
   step=62  time=3.1e-05
@@ -1644,10 +1644,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 4.99077 0.00632785
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.308558
   Solving crack phase field at step=62 time=3.1e-05
-  Primary solution summary: L2-norm      : 0.8617
-                            Max value    : 0.987361
-                            Min value    : -0.0296735
-                            Range        : 1.02967
+  L2-norm            : 0.8617
+  Max value          : 0.987361
+  Min value          : -0.0296735
+  Range              : 1.02967
   Dissipated energy:               eps_d : 0.0746072
   >>> Paused for mesh refinement at time=3.1e-05
   Lowest element:      ...    |c| = 0.000556957
@@ -1671,10 +1671,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 5.42162 0.00614822
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.31399
   Solving crack phase field at step=63 time=3.15e-05
-  Primary solution summary: L2-norm      : 0.860813
-                            Max value    : 0.98736
-                            Min value    : -0.0270981
-                            Range        : 1.0271
+  L2-norm            : 0.860813
+  Max value          : 0.98736
+  Min value          : -0.0270981
+  Range              : 1.0271
   Dissipated energy:               eps_d : 0.0758147
   Solving the elasto-dynamics problem...
   step=64  time=3.2e-05
@@ -1692,10 +1692,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 5.89118 0.00582089
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.319453
   Solving crack phase field at step=64 time=3.2e-05
-  Primary solution summary: L2-norm      : 0.859929
-                            Max value    : 0.98736
-                            Min value    : -0.0246659
-                            Range        : 1.02467
+  L2-norm            : 0.859929
+  Max value          : 0.98736
+  Min value          : -0.0246659
+  Range              : 1.02467
   Dissipated energy:               eps_d : 0.0770861
   >>> Paused for mesh refinement at time=3.2e-05
   Lowest element:      ...    |c| = 0.000539556
@@ -1719,10 +1719,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 6.39356 0.00541094
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.324851
   Solving crack phase field at step=65 time=3.25e-05
-  Primary solution summary: L2-norm      : 0.859046
-                            Max value    : 0.987359
-                            Min value    : -0.0223134
-                            Range        : 1.02231
+  L2-norm            : 0.859046
+  Max value          : 0.987359
+  Min value          : -0.0223134
+  Range              : 1.02231
   Dissipated energy:               eps_d : 0.0784267
   Solving the elasto-dynamics problem...
   step=66  time=3.3e-05
@@ -1740,10 +1740,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 6.92099 0.00497959
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.330142
   Solving crack phase field at step=66 time=3.3e-05
-  Primary solution summary: L2-norm      : 0.85815
-                            Max value    : 0.987359
-                            Min value    : -0.0200827
-                            Range        : 1.02008
+  L2-norm            : 0.85815
+  Max value          : 0.987359
+  Min value          : -0.0200827
+  Range              : 1.02008
   Dissipated energy:               eps_d : 0.0798304
   >>> Paused for mesh refinement at time=3.3e-05
   Lowest element:      ...    |c| = 2.4023e-05
@@ -1767,10 +1767,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 7.46218 0.00454209
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.335353
   Solving crack phase field at step=67 time=3.35e-05
-  Primary solution summary: L2-norm      : 0.857275
-                            Max value    : 0.987358
-                            Min value    : -0.0180638
-                            Range        : 1.01806
+  L2-norm            : 0.857275
+  Max value          : 0.987358
+  Min value          : -0.0180638
+  Range              : 1.01806
   Dissipated energy:               eps_d : 0.0812622
   Solving the elasto-dynamics problem...
   step=68  time=3.4e-05
@@ -1788,10 +1788,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 8.00879 0.00411071
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.340588
   Solving crack phase field at step=68 time=3.4e-05
-  Primary solution summary: L2-norm      : 0.856427
-                            Max value    : 0.987358
-                            Min value    : -0.0162857
-                            Range        : 1.01629
+  L2-norm            : 0.856427
+  Max value          : 0.987358
+  Min value          : -0.0162857
+  Range              : 1.01629
   Dissipated energy:               eps_d : 0.0827119
   >>> Paused for mesh refinement at time=3.4e-05
   Lowest element:      ...    |c| = 0.000284978
@@ -1815,10 +1815,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 8.56357 0.00370919
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.346007
   Solving crack phase field at step=69 time=3.45e-05
-  Primary solution summary: L2-norm      : 0.855599
-                            Max value    : 0.987357
-                            Min value    : -0.0147542
-                            Range        : 1.01475
+  L2-norm            : 0.855599
+  Max value          : 0.987357
+  Min value          : -0.0147542
+  Range              : 1.01475
   Dissipated energy:               eps_d : 0.084184
   Solving the elasto-dynamics problem...
   step=70  time=3.5e-05
@@ -1836,10 +1836,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 9.13869 0.00336234
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.351772
   Solving crack phase field at step=70 time=3.5e-05
-  Primary solution summary: L2-norm      : 0.85475
-                            Max value    : 0.987357
-                            Min value    : -0.0134368
-                            Range        : 1.01344
+  L2-norm            : 0.85475
+  Max value          : 0.987357
+  Min value          : -0.0134368
+  Range              : 1.01344
   Dissipated energy:               eps_d : 0.0857119
   >>> Paused for mesh refinement at time=3.5e-05
   Lowest element:      ...    |c| = 0.000435934
@@ -1863,10 +1863,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 9.74546 0.0030921
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.357993
   Solving crack phase field at step=71 time=3.55e-05
-  Primary solution summary: L2-norm      : 0.853879
-                            Max value    : 0.987357
-                            Min value    : -0.0122719
-                            Range        : 1.01227
+  L2-norm            : 0.853879
+  Max value          : 0.987357
+  Min value          : -0.0122719
+  Range              : 1.01227
   Dissipated energy:               eps_d : 0.0873034
   Solving the elasto-dynamics problem...
   step=72  time=3.6e-05
@@ -1884,10 +1884,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 10.3887 0.00286384
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.364689
   Solving crack phase field at step=72 time=3.6e-05
-  Primary solution summary: L2-norm      : 0.853045
-                            Max value    : 0.987356
-                            Min value    : -0.0112038
-                            Range        : 1.0112
+  L2-norm            : 0.853045
+  Max value          : 0.987356
+  Min value          : -0.0112038
+  Range              : 1.0112
   Dissipated energy:               eps_d : 0.088921
   >>> Paused for mesh refinement at time=3.6e-05
   Lowest element:      ...    |c| = 0.00046233
@@ -1911,10 +1911,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 11.0719 0.00255292
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.371786
   Solving crack phase field at step=73 time=3.65e-05
-  Primary solution summary: L2-norm      : 0.852239
-                            Max value    : 0.987356
-                            Min value    : -0.0102091
-                            Range        : 1.01021
+  L2-norm            : 0.852239
+  Max value          : 0.987356
+  Min value          : -0.0102091
+  Range              : 1.01021
   Dissipated energy:               eps_d : 0.0905612
   Solving the elasto-dynamics problem...
   step=74  time=3.7e-05
@@ -1932,10 +1932,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 11.7957 0.00224058
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.379143
   Solving crack phase field at step=74 time=3.7e-05
-  Primary solution summary: L2-norm      : 0.851476
-                            Max value    : 0.987356
-                            Min value    : -0.00930039
-                            Range        : 1.0093
+  L2-norm            : 0.851476
+  Max value          : 0.987356
+  Min value          : -0.00930039
+  Range              : 1.0093
   Dissipated energy:               eps_d : 0.0922166
   >>> Paused for mesh refinement at time=3.7e-05
   Lowest element:      ...    |c| = 0.000410396
@@ -1959,10 +1959,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 12.5463 0.00201836
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.386593
   Solving crack phase field at step=75 time=3.75e-05
-  Primary solution summary: L2-norm      : 0.850725
-                            Max value    : 0.987356
-                            Min value    : -0.00848646
-                            Range        : 1.00849
+  L2-norm            : 0.850725
+  Max value          : 0.987356
+  Min value          : -0.00848646
+  Range              : 1.00849
   Dissipated energy:               eps_d : 0.0938734
   Solving the elasto-dynamics problem...
   step=76  time=3.8e-05
@@ -1980,10 +1980,10 @@ Number of unknowns    616
   Tensile & compressive energies         : 13.3039 0.0018878
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.393992
   Solving crack phase field at step=76 time=3.8e-05
-  Primary solution summary: L2-norm      : 0.850022
-                            Max value    : 0.987355
-                            Min value    : -0.00775838
-                            Range        : 1.00776
+  L2-norm            : 0.850022
+  Max value          : 0.987355
+  Min value          : -0.00775838
+  Range              : 1.00776
   Dissipated energy:               eps_d : 0.0954992
   >>> Paused for mesh refinement at time=3.8e-05
   Lowest element:      ...    |c| = 0.000362744
@@ -2071,10 +2071,10 @@ Transferring 1136 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 12.5429 0.00200516
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.386593
   Solving crack phase field at step=75 time=3.75e-05
-  Primary solution summary: L2-norm      : 0.838679
-                            Max value    : 0.987356
-                            Min value    : -0.00842785
-                            Range        : 1.00843
+  L2-norm            : 0.838679
+  Max value          : 0.987356
+  Min value          : -0.00842785
+  Range              : 1.00843
   Dissipated energy:               eps_d : 0.0937311
   Solving the elasto-dynamics problem...
   step=76  time=3.8e-05
@@ -2092,10 +2092,10 @@ Transferring 1136 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 13.3075 0.00187632
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.393992
   Solving crack phase field at step=76 time=3.8e-05
-  Primary solution summary: L2-norm      : 0.83704
-                            Max value    : 0.987356
-                            Min value    : -0.00770191
-                            Range        : 1.0077
+  L2-norm            : 0.83704
+  Max value          : 0.987356
+  Min value          : -0.00770191
+  Range              : 1.0077
   Dissipated energy:               eps_d : 0.0954224
   Solving the elasto-dynamics problem...
   step=77  time=3.85e-05
@@ -2113,10 +2113,10 @@ Transferring 1136 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 14.0909 0.0018477
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.401259
   Solving crack phase field at step=77 time=3.85e-05
-  Primary solution summary: L2-norm      : 0.835702
-                            Max value    : 0.987356
-                            Min value    : -0.00708586
-                            Range        : 1.00709
+  L2-norm            : 0.835702
+  Max value          : 0.987356
+  Min value          : -0.00708586
+  Range              : 1.00709
   Dissipated energy:               eps_d : 0.096935
   >>> Paused for mesh refinement at time=3.85e-05
   Lowest element:      ...    |c| = 0.000341245
@@ -2140,10 +2140,10 @@ Transferring 1136 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 14.9055 0.00185419
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.40837
   Solving crack phase field at step=78 time=3.9e-05
-  Primary solution summary: L2-norm      : 0.83434
-                            Max value    : 0.987356
-                            Min value    : -0.00656938
-                            Range        : 1.00657
+  L2-norm            : 0.83434
+  Max value          : 0.987356
+  Min value          : -0.00656938
+  Range              : 1.00657
   Dissipated energy:               eps_d : 0.0985404
   Solving the elasto-dynamics problem...
   step=79  time=3.95e-05
@@ -2161,10 +2161,10 @@ Transferring 1136 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 15.7617 0.00188281
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.415339
   Solving crack phase field at step=79 time=3.95e-05
-  Primary solution summary: L2-norm      : 0.832971
-                            Max value    : 0.987356
-                            Min value    : -0.00611408
-                            Range        : 1.00611
+  L2-norm            : 0.832971
+  Max value          : 0.987356
+  Min value          : -0.00611408
+  Range              : 1.00611
   Dissipated energy:               eps_d : 0.100062
   >>> Paused for mesh refinement at time=3.95e-05
   Lowest element:      ...    |c| = 0.000303939
@@ -2188,9 +2188,9 @@ Transferring 1136 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 16.6735 0.00171962
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.422197
   Solving crack phase field at step=80 time=4e-05
-  Primary solution summary: L2-norm      : 0.831624
-                            Max value    : 0.987355
-                            Min value    : -0.00570466
-                            Range        : 1.0057
+  L2-norm            : 0.831624
+  Max value          : 0.987355
+  Min value          : -0.00570466
+  Range              : 1.0057
   Dissipated energy:               eps_d : 0.10161
   Time integration completed.

--- a/Test/Short10x20-p1-adap-restart.reg
+++ b/Test/Short10x20-p1-adap-restart.reg
@@ -113,10 +113,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 13.3075 0.00187632
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.393992
   Solving crack phase field at step=76 time=3.8e-05
-  Primary solution summary: L2-norm      : 0.83704
-                            Max value    : 0.987356
-                            Min value    : -0.00770191
-                            Range        : 1.0077
+  L2-norm            : 0.83704
+  Max value          : 0.987356
+  Min value          : -0.00770191
+  Range              : 1.0077
   Dissipated energy:               eps_d : 0.0954224
   Solving the elasto-dynamics problem...
   step=77  time=3.85e-05
@@ -134,10 +134,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 14.0909 0.0018477
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.401259
   Solving crack phase field at step=77 time=3.85e-05
-  Primary solution summary: L2-norm      : 0.835702
-                            Max value    : 0.987356
-                            Min value    : -0.00708586
-                            Range        : 1.00709
+  L2-norm            : 0.835702
+  Max value          : 0.987356
+  Min value          : -0.00708586
+  Range              : 1.00709
   Dissipated energy:               eps_d : 0.096935
   >>> Paused for mesh refinement at time=3.85e-05
   Lowest element:      ...    |c| = 0.000341245
@@ -161,10 +161,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 14.9055 0.00185419
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.40837
   Solving crack phase field at step=78 time=3.9e-05
-  Primary solution summary: L2-norm      : 0.83434
-                            Max value    : 0.987356
-                            Min value    : -0.00656938
-                            Range        : 1.00657
+  L2-norm            : 0.83434
+  Max value          : 0.987356
+  Min value          : -0.00656938
+  Range              : 1.00657
   Dissipated energy:               eps_d : 0.0985404
   Solving the elasto-dynamics problem...
   step=79  time=3.95e-05
@@ -182,10 +182,10 @@ Number of unknowns    330
   Tensile & compressive energies         : 15.7617 0.00188281
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.415339
   Solving crack phase field at step=79 time=3.95e-05
-  Primary solution summary: L2-norm      : 0.832971
-                            Max value    : 0.987356
-                            Min value    : -0.00611408
-                            Range        : 1.00611
+  L2-norm            : 0.832971
+  Max value          : 0.987356
+  Min value          : -0.00611408
+  Range              : 1.00611
   Dissipated energy:               eps_d : 0.100062
   >>> Paused for mesh refinement at time=3.95e-05
   Lowest element:      ...    |c| = 0.000303939
@@ -209,9 +209,9 @@ Number of unknowns    330
   Tensile & compressive energies         : 16.6735 0.00171962
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.422197
   Solving crack phase field at step=80 time=4e-05
-  Primary solution summary: L2-norm      : 0.831624
-                            Max value    : 0.987355
-                            Min value    : -0.00570466
-                            Range        : 1.0057
+  L2-norm            : 0.831624
+  Max value          : 0.987355
+  Min value          : -0.00570466
+  Range              : 1.0057
   Dissipated energy:               eps_d : 0.10161
   Time integration completed.

--- a/Test/Short10x20-preref_FD.reg
+++ b/Test/Short10x20-preref_FD.reg
@@ -151,10 +151,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.0004358 6.244e-07
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.03913
   Solving crack phase field at step=1 time=5e-07
-  Primary solution summary: L2-norm      : 0.9078
-                            Max value    : 0.9999
-                            Min value    : -0.02175
-                            Range        : 1.022
+  L2-norm            : 0.9078
+  Max value          : 0.9999
+  Min value          : -0.02175
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0299886
   Solving the elasto-dynamics problem...
   step=2  time=1e-06
@@ -172,10 +172,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.001943 8.672e-06
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.06404
   Solving crack phase field at step=2 time=1e-06
-  Primary solution summary: L2-norm      : 0.9053
-                            Max value    : 0.9998
-                            Min value    : -0.02175
-                            Range        : 1.022
+  L2-norm            : 0.9053
+  Max value          : 0.9998
+  Min value          : -0.02175
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0300157
   >>> Paused for mesh refinement at time=1e-06
   Lowest element:      ...    |c| = 5.697e-05
@@ -199,10 +199,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.002913 2.917e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.07898
   Solving crack phase field at step=3 time=1.5e-06
-  Primary solution summary: L2-norm      : 0.9034
-                            Max value    : 0.9997
-                            Min value    : -0.02175
-                            Range        : 1.022
+  L2-norm            : 0.9034
+  Max value          : 0.9997
+  Min value          : -0.02175
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0300461
   Solving the elasto-dynamics problem...
   step=4  time=2e-06
@@ -220,10 +220,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.003849 5.702e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.09119
   Solving crack phase field at step=4 time=2e-06
-  Primary solution summary: L2-norm      : 0.9016
-                            Max value    : 0.9996
-                            Min value    : -0.02175
-                            Range        : 1.022
+  L2-norm            : 0.9016
+  Max value          : 0.9996
+  Min value          : -0.02175
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0300763
   >>> Paused for mesh refinement at time=2e-06
   Lowest element:      ...    |c| = 5.7e-05
@@ -247,10 +247,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.00509 9.369e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1035
   Solving crack phase field at step=5 time=2.5e-06
-  Primary solution summary: L2-norm      : 0.8997
-                            Max value    : 0.9996
-                            Min value    : -0.02175
-                            Range        : 1.022
+  L2-norm            : 0.8997
+  Max value          : 0.9996
+  Min value          : -0.02175
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.030112
   Solving the elasto-dynamics problem...
   step=6  time=3e-06
@@ -268,10 +268,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.006188 0.0001432
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1141
   Solving crack phase field at step=6 time=3e-06
-  Primary solution summary: L2-norm      : 0.8978
-                            Max value    : 0.9995
-                            Min value    : -0.02175
-                            Range        : 1.022
+  L2-norm            : 0.8978
+  Max value          : 0.9995
+  Min value          : -0.02175
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0301483
   >>> Paused for mesh refinement at time=3e-06
   Lowest element:      ...    |c| = 5.723e-05
@@ -295,10 +295,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.007153 0.0002107
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1232
   Solving crack phase field at step=7 time=3.5e-06
-  Primary solution summary: L2-norm      : 0.896
-                            Max value    : 0.9993
-                            Min value    : -0.02174
-                            Range        : 1.022
+  L2-norm            : 0.896
+  Max value          : 0.9993
+  Min value          : -0.02174
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0301822
   Solving the elasto-dynamics problem...
   step=8  time=4e-06
@@ -316,10 +316,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.008256 0.0003063
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1323
   Solving crack phase field at step=8 time=4e-06
-  Primary solution summary: L2-norm      : 0.8942
-                            Max value    : 0.9988
-                            Min value    : -0.02173
-                            Range        : 1.022
+  L2-norm            : 0.8942
+  Max value          : 0.9988
+  Min value          : -0.02173
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0302136
   >>> Paused for mesh refinement at time=4e-06
   Lowest element:      ...    |c| = 5.863e-05
@@ -343,10 +343,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.009397 0.0004343
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1409
   Solving crack phase field at step=9 time=4.5e-06
-  Primary solution summary: L2-norm      : 0.8923
-                            Max value    : 0.9975
-                            Min value    : -0.0217
-                            Range        : 1.022
+  L2-norm            : 0.8923
+  Max value          : 0.9975
+  Min value          : -0.0217
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.0302473
   Solving the elasto-dynamics problem...
   step=10  time=5e-06
@@ -364,10 +364,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.01054 0.0005908
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1488
   Solving crack phase field at step=10 time=5e-06
-  Primary solution summary: L2-norm      : 0.8902
-                            Max value    : 0.9936
-                            Min value    : -0.02162
-                            Range        : 1.022
+  L2-norm            : 0.8902
+  Max value          : 0.9936
+  Min value          : -0.02162
+  Range              : 1.022
   Dissipated energy:               eps_d : 0.030288
   >>> Paused for mesh refinement at time=5e-06
   Lowest element:      ...    |c| = 6.61e-05
@@ -391,10 +391,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.01224 0.0007674
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1564
   Solving crack phase field at step=11 time=5.5e-06
-  Primary solution summary: L2-norm      : 0.8874
-                            Max value    : 0.9835
-                            Min value    : -0.02146
-                            Range        : 1.021
+  L2-norm            : 0.8874
+  Max value          : 0.9835
+  Min value          : -0.02146
+  Range              : 1.021
   Dissipated energy:               eps_d : 0.0303481
   Solving the elasto-dynamics problem...
   step=12  time=6e-06
@@ -412,10 +412,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.01538 0.0009521
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1638
   Solving crack phase field at step=12 time=6e-06
-  Primary solution summary: L2-norm      : 0.8838
-                            Max value    : 0.9751
-                            Min value    : -0.02115
-                            Range        : 1.021
+  L2-norm            : 0.8838
+  Max value          : 0.9751
+  Min value          : -0.02115
+  Range              : 1.021
   Dissipated energy:               eps_d : 0.0304658
   >>> Paused for mesh refinement at time=6e-06
   Lowest element:      ...    |c| = 9.521e-05
@@ -439,10 +439,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.02077 0.001132
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1708
   Solving crack phase field at step=13 time=6.5e-06
-  Primary solution summary: L2-norm      : 0.8796
-                            Max value    : 0.9748
-                            Min value    : -0.02069
-                            Range        : 1.021
+  L2-norm            : 0.8796
+  Max value          : 0.9748
+  Min value          : -0.02069
+  Range              : 1.021
   Dissipated energy:               eps_d : 0.0306821
   Solving the elasto-dynamics problem...
   step=14  time=7e-06
@@ -460,10 +460,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.02884 0.001302
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1775
   Solving crack phase field at step=14 time=7e-06
-  Primary solution summary: L2-norm      : 0.8759
-                            Max value    : 0.9744
-                            Min value    : -0.02023
-                            Range        : 1.02
+  L2-norm            : 0.8759
+  Max value          : 0.9744
+  Min value          : -0.02023
+  Range              : 1.02
   Dissipated energy:               eps_d : 0.0309389
   >>> Paused for mesh refinement at time=7e-06
   Lowest element:      ...    |c| = 0.0001377
@@ -487,10 +487,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.04177 0.001477
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1841
   Solving crack phase field at step=15 time=7.5e-06
-  Primary solution summary: L2-norm      : 0.8723
-                            Max value    : 0.9741
-                            Min value    : -0.01977
-                            Range        : 1.02
+  L2-norm            : 0.8723
+  Max value          : 0.9741
+  Min value          : -0.01977
+  Range              : 1.02
   Dissipated energy:               eps_d : 0.031187
   Solving the elasto-dynamics problem...
   step=16  time=8e-06
@@ -508,10 +508,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.06565 0.001666
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1904
   Solving crack phase field at step=16 time=8e-06
-  Primary solution summary: L2-norm      : 0.8681
-                            Max value    : 0.9739
-                            Min value    : -0.01938
-                            Range        : 1.019
+  L2-norm            : 0.8681
+  Max value          : 0.9739
+  Min value          : -0.01938
+  Range              : 1.019
   Dissipated energy:               eps_d : 0.0315067
   >>> Paused for mesh refinement at time=8e-06
   Lowest element:      ...    |c| = 0.0001537
@@ -535,10 +535,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.1045 0.00189
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.1966
   Solving crack phase field at step=17 time=8.5e-06
-  Primary solution summary: L2-norm      : 0.864
-                            Max value    : 0.9738
-                            Min value    : -0.01904
-                            Range        : 1.019
+  L2-norm            : 0.864
+  Max value          : 0.9738
+  Min value          : -0.01904
+  Range              : 1.019
   Dissipated energy:               eps_d : 0.0318301
   Solving the elasto-dynamics problem...
   step=18  time=9e-06
@@ -556,10 +556,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.1429 0.002169
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2027
   Solving crack phase field at step=18 time=9e-06
-  Primary solution summary: L2-norm      : 0.8596
-                            Max value    : 0.9738
-                            Min value    : -0.01865
-                            Range        : 1.019
+  L2-norm            : 0.8596
+  Max value          : 0.9738
+  Min value          : -0.01865
+  Range              : 1.019
   Dissipated energy:               eps_d : 0.0322219
   >>> Paused for mesh refinement at time=9e-06
   Lowest element:      ...    |c| = 0.00017
@@ -583,10 +583,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.1721 0.002284
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2087
   Solving crack phase field at step=19 time=9.5e-06
-  Primary solution summary: L2-norm      : 0.8546
-                            Max value    : 0.9737
-                            Min value    : -0.01814
-                            Range        : 1.018
+  L2-norm            : 0.8546
+  Max value          : 0.9737
+  Min value          : -0.01814
+  Range              : 1.018
   Dissipated energy:               eps_d : 0.0327146
   Solving the elasto-dynamics problem...
   step=20  time=1e-05
@@ -604,10 +604,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.1998 0.00226
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2145
   Solving crack phase field at step=20 time=1e-05
-  Primary solution summary: L2-norm      : 0.8492
-                            Max value    : 0.9737
-                            Min value    : -0.01753
-                            Range        : 1.018
+  L2-norm            : 0.8492
+  Max value          : 0.9737
+  Min value          : -0.01753
+  Range              : 1.018
   Dissipated energy:               eps_d : 0.0333187
   >>> Paused for mesh refinement at time=1e-05
   Lowest element:      ...    |c| = 0.0001909
@@ -631,10 +631,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.2291 0.002152
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2201
   Solving crack phase field at step=21 time=1.05e-05
-  Primary solution summary: L2-norm      : 0.8439
-                            Max value    : 0.9736
-                            Min value    : -0.01688
-                            Range        : 1.017
+  L2-norm            : 0.8439
+  Max value          : 0.9736
+  Min value          : -0.01688
+  Range              : 1.017
   Dissipated energy:               eps_d : 0.0340127
   Solving the elasto-dynamics problem...
   step=22  time=1.1e-05
@@ -652,10 +652,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.2595 0.002022
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2253
   Solving crack phase field at step=22 time=1.1e-05
-  Primary solution summary: L2-norm      : 0.8389
-                            Max value    : 0.9736
-                            Min value    : -0.01626
-                            Range        : 1.016
+  L2-norm            : 0.8389
+  Max value          : 0.9736
+  Min value          : -0.01626
+  Range              : 1.016
   Dissipated energy:               eps_d : 0.0347668
   >>> Paused for mesh refinement at time=1.1e-05
   Lowest element:      ...    |c| = 2.815e-05
@@ -679,10 +679,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.2908 0.001914
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2298
   Solving crack phase field at step=23 time=1.15e-05
-  Primary solution summary: L2-norm      : 0.8344
-                            Max value    : 0.9734
-                            Min value    : -0.01565
-                            Range        : 1.016
+  L2-norm            : 0.8344
+  Max value          : 0.9734
+  Min value          : -0.01565
+  Range              : 1.016
   Dissipated energy:               eps_d : 0.0355609
   Solving the elasto-dynamics problem...
   step=24  time=1.2e-05
@@ -700,10 +700,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.3229 0.001802
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2336
   Solving crack phase field at step=24 time=1.2e-05
-  Primary solution summary: L2-norm      : 0.8306
-                            Max value    : 0.9734
-                            Min value    : -0.01507
-                            Range        : 1.015
+  L2-norm            : 0.8306
+  Max value          : 0.9734
+  Min value          : -0.01507
+  Range              : 1.015
   Dissipated energy:               eps_d : 0.0363568
   >>> Paused for mesh refinement at time=1.2e-05
   Lowest element:      ...    |c| = 8.125e-05
@@ -727,10 +727,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.3563 0.001748
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2366
   Solving crack phase field at step=25 time=1.25e-05
-  Primary solution summary: L2-norm      : 0.8271
-                            Max value    : 0.9733
-                            Min value    : -0.0145
-                            Range        : 1.014
+  L2-norm            : 0.8271
+  Max value          : 0.9733
+  Min value          : -0.0145
+  Range              : 1.014
   Dissipated energy:               eps_d : 0.0371728
   Solving the elasto-dynamics problem...
   step=26  time=1.3e-05
@@ -748,10 +748,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.3912 0.001753
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2389
   Solving crack phase field at step=26 time=1.3e-05
-  Primary solution summary: L2-norm      : 0.8239
-                            Max value    : 0.9733
-                            Min value    : -0.01398
-                            Range        : 1.014
+  L2-norm            : 0.8239
+  Max value          : 0.9733
+  Min value          : -0.01398
+  Range              : 1.014
   Dissipated energy:               eps_d : 0.0379908
   >>> Paused for mesh refinement at time=1.3e-05
   Lowest element:      ...    |c| = 0.0001307
@@ -775,10 +775,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.4285 0.001752
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2411
   Solving crack phase field at step=27 time=1.35e-05
-  Primary solution summary: L2-norm      : 0.8211
-                            Max value    : 0.9732
-                            Min value    : -0.01354
-                            Range        : 1.014
+  L2-norm            : 0.8211
+  Max value          : 0.9732
+  Min value          : -0.01354
+  Range              : 1.014
   Dissipated energy:               eps_d : 0.0388054
   Solving the elasto-dynamics problem...
   step=28  time=1.4e-05
@@ -796,10 +796,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.4691 0.00171
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2436
   Solving crack phase field at step=28 time=1.4e-05
-  Primary solution summary: L2-norm      : 0.8186
-                            Max value    : 0.9732
-                            Min value    : -0.01314
-                            Range        : 1.013
+  L2-norm            : 0.8186
+  Max value          : 0.9732
+  Min value          : -0.01314
+  Range              : 1.013
   Dissipated energy:               eps_d : 0.0396294
   >>> Paused for mesh refinement at time=1.4e-05
   Lowest element:      ...    |c| = 0.0001693
@@ -823,10 +823,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.5138 0.001658
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2465
   Solving crack phase field at step=29 time=1.45e-05
-  Primary solution summary: L2-norm      : 0.8162
-                            Max value    : 0.973
-                            Min value    : -0.01275
-                            Range        : 1.013
+  L2-norm            : 0.8162
+  Max value          : 0.973
+  Min value          : -0.01275
+  Range              : 1.013
   Dissipated energy:               eps_d : 0.040504
   Solving the elasto-dynamics problem...
   step=30  time=1.5e-05
@@ -844,10 +844,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.5627 0.001639
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2493
   Solving crack phase field at step=30 time=1.5e-05
-  Primary solution summary: L2-norm      : 0.8134
-                            Max value    : 0.9701
-                            Min value    : -0.01237
-                            Range        : 1.012
+  L2-norm            : 0.8134
+  Max value          : 0.9701
+  Min value          : -0.01237
+  Range              : 1.012
   Dissipated energy:               eps_d : 0.0414556
   >>> Paused for mesh refinement at time=1.5e-05
   Lowest element:      ...    |c| = 0.0002047
@@ -871,10 +871,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.6166 0.001653
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2511
   Solving crack phase field at step=31 time=1.55e-05
-  Primary solution summary: L2-norm      : 0.8112
-                            Max value    : 0.9697
-                            Min value    : -0.01201
-                            Range        : 1.012
+  L2-norm            : 0.8112
+  Max value          : 0.9697
+  Min value          : -0.01201
+  Range              : 1.012
   Dissipated energy:               eps_d : 0.0424338
   Solving the elasto-dynamics problem...
   step=32  time=1.6e-05
@@ -892,10 +892,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.676 0.0017
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.252
   Solving crack phase field at step=32 time=1.6e-05
-  Primary solution summary: L2-norm      : 0.8094
-                            Max value    : 0.9697
-                            Min value    : -0.01168
-                            Range        : 1.012
+  L2-norm            : 0.8094
+  Max value          : 0.9697
+  Min value          : -0.01168
+  Range              : 1.012
   Dissipated energy:               eps_d : 0.0434314
   >>> Paused for mesh refinement at time=1.6e-05
   Lowest element:      ...    |c| = 0.0002373
@@ -919,10 +919,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.7398 0.001771
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2525
   Solving crack phase field at step=33 time=1.65e-05
-  Primary solution summary: L2-norm      : 0.8078
-                            Max value    : 0.9697
-                            Min value    : -0.01141
-                            Range        : 1.011
+  L2-norm            : 0.8078
+  Max value          : 0.9697
+  Min value          : -0.01141
+  Range              : 1.011
   Dissipated energy:               eps_d : 0.0444271
   Solving the elasto-dynamics problem...
   step=34  time=1.7e-05
@@ -940,10 +940,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.8049 0.001824
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2531
   Solving crack phase field at step=34 time=1.7e-05
-  Primary solution summary: L2-norm      : 0.8064
-                            Max value    : 0.9697
-                            Min value    : -0.01119
-                            Range        : 1.011
+  L2-norm            : 0.8064
+  Max value          : 0.9697
+  Min value          : -0.01119
+  Range              : 1.011
   Dissipated energy:               eps_d : 0.0453835
   >>> Paused for mesh refinement at time=1.7e-05
   Lowest element:      ...    |c| = 0.0002608
@@ -967,10 +967,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.871 0.001861
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2537
   Solving crack phase field at step=35 time=1.75e-05
-  Primary solution summary: L2-norm      : 0.8052
-                            Max value    : 0.9697
-                            Min value    : -0.01101
-                            Range        : 1.011
+  L2-norm            : 0.8052
+  Max value          : 0.9697
+  Min value          : -0.01101
+  Range              : 1.011
   Dissipated energy:               eps_d : 0.0462552
   Solving the elasto-dynamics problem...
   step=36  time=1.8e-05
@@ -988,10 +988,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 0.9381 0.001879
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2543
   Solving crack phase field at step=36 time=1.8e-05
-  Primary solution summary: L2-norm      : 0.8042
-                            Max value    : 0.9695
-                            Min value    : -0.01085
-                            Range        : 1.011
+  L2-norm            : 0.8042
+  Max value          : 0.9695
+  Min value          : -0.01085
+  Range              : 1.011
   Dissipated energy:               eps_d : 0.0470436
   >>> Paused for mesh refinement at time=1.8e-05
   Lowest element:      ...    |c| = 0.0002771
@@ -1015,10 +1015,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.006 0.001849
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2548
   Solving crack phase field at step=37 time=1.85e-05
-  Primary solution summary: L2-norm      : 0.8033
-                            Max value    : 0.9689
-                            Min value    : -0.01071
-                            Range        : 1.011
+  L2-norm            : 0.8033
+  Max value          : 0.9689
+  Min value          : -0.01071
+  Range              : 1.011
   Dissipated energy:               eps_d : 0.0477677
   Solving the elasto-dynamics problem...
   step=38  time=1.9e-05
@@ -1036,10 +1036,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.075 0.001722
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2554
   Solving crack phase field at step=38 time=1.9e-05
-  Primary solution summary: L2-norm      : 0.8024
-                            Max value    : 0.9689
-                            Min value    : -0.01058
-                            Range        : 1.011
+  L2-norm            : 0.8024
+  Max value          : 0.9689
+  Min value          : -0.01058
+  Range              : 1.011
   Dissipated energy:               eps_d : 0.0484561
   >>> Paused for mesh refinement at time=1.9e-05
   Lowest element:      ...    |c| = 0.0002906
@@ -1063,10 +1063,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.145 0.001527
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.256
   Solving crack phase field at step=39 time=1.95e-05
-  Primary solution summary: L2-norm      : 0.8016
-                            Max value    : 0.9689
-                            Min value    : -0.01047
-                            Range        : 1.01
+  L2-norm            : 0.8016
+  Max value          : 0.9689
+  Min value          : -0.01047
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0491397
   Solving the elasto-dynamics problem...
   step=40  time=2e-05
@@ -1084,10 +1084,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.221 0.001309
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2566
   Solving crack phase field at step=40 time=2e-05
-  Primary solution summary: L2-norm      : 0.8008
-                            Max value    : 0.9689
-                            Min value    : -0.01035
-                            Range        : 1.01
+  L2-norm            : 0.8008
+  Max value          : 0.9689
+  Min value          : -0.01035
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0498368
   >>> Paused for mesh refinement at time=2e-05
   Lowest element:      ...    |c| = 0.000302
@@ -1111,10 +1111,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.311 0.001131
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2573
   Solving crack phase field at step=41 time=2.05e-05
-  Primary solution summary: L2-norm      : 0.8
-                            Max value    : 0.9689
-                            Min value    : -0.01024
-                            Range        : 1.01
+  L2-norm            : 0.8
+  Max value          : 0.9689
+  Min value          : -0.01024
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0505567
   Solving the elasto-dynamics problem...
   step=42  time=2.1e-05
@@ -1132,10 +1132,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.421 0.001036
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2581
   Solving crack phase field at step=42 time=2.1e-05
-  Primary solution summary: L2-norm      : 0.7992
-                            Max value    : 0.9689
-                            Min value    : -0.01014
-                            Range        : 1.01
+  L2-norm            : 0.7992
+  Max value          : 0.9689
+  Min value          : -0.01014
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0512896
   >>> Paused for mesh refinement at time=2.1e-05
   Lowest element:      ...    |c| = 0.0003126
@@ -1159,10 +1159,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.555 0.0009891
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2592
   Solving crack phase field at step=43 time=2.15e-05
-  Primary solution summary: L2-norm      : 0.7985
-                            Max value    : 0.9689
-                            Min value    : -0.01004
-                            Range        : 1.01
+  L2-norm            : 0.7985
+  Max value          : 0.9689
+  Min value          : -0.01004
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0519801
   Solving the elasto-dynamics problem...
   step=44  time=2.2e-05
@@ -1180,10 +1180,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.709 0.00109
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2603
   Solving crack phase field at step=44 time=2.2e-05
-  Primary solution summary: L2-norm      : 0.798
-                            Max value    : 0.9689
-                            Min value    : -0.009968
-                            Range        : 1.01
+  L2-norm            : 0.798
+  Max value          : 0.9689
+  Min value          : -0.009968
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0525683
   >>> Paused for mesh refinement at time=2.2e-05
   Lowest element:      ...    |c| = 0.0003211
@@ -1207,10 +1207,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 1.87 0.001238
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2616
   Solving crack phase field at step=45 time=2.25e-05
-  Primary solution summary: L2-norm      : 0.7975
-                            Max value    : 0.9689
-                            Min value    : -0.009913
-                            Range        : 1.01
+  L2-norm            : 0.7975
+  Max value          : 0.9689
+  Min value          : -0.009913
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0530502
   Solving the elasto-dynamics problem...
   step=46  time=2.3e-05
@@ -1228,10 +1228,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 2.03 0.001437
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2631
   Solving crack phase field at step=46 time=2.3e-05
-  Primary solution summary: L2-norm      : 0.7971
-                            Max value    : 0.9689
-                            Min value    : -0.00986
-                            Range        : 1.01
+  L2-norm            : 0.7971
+  Max value          : 0.9689
+  Min value          : -0.00986
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0535011
   >>> Paused for mesh refinement at time=2.3e-05
   Lowest element:      ...    |c| = 0.0002329
@@ -1255,10 +1255,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 2.189 0.001642
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2648
   Solving crack phase field at step=47 time=2.35e-05
-  Primary solution summary: L2-norm      : 0.7966
-                            Max value    : 0.9689
-                            Min value    : -0.009811
-                            Range        : 1.01
+  L2-norm            : 0.7966
+  Max value          : 0.9689
+  Min value          : -0.009811
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0539809
   Solving the elasto-dynamics problem...
   step=48  time=2.4e-05
@@ -1276,10 +1276,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 2.355 0.001863
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2669
   Solving crack phase field at step=48 time=2.4e-05
-  Primary solution summary: L2-norm      : 0.7961
-                            Max value    : 0.9689
-                            Min value    : -0.009766
-                            Range        : 1.01
+  L2-norm            : 0.7961
+  Max value          : 0.9689
+  Min value          : -0.009766
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0545089
   >>> Paused for mesh refinement at time=2.4e-05
   Lowest element:      ...    |c| = 3.521e-05
@@ -1303,10 +1303,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 2.527 0.002099
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2694
   Solving crack phase field at step=49 time=2.45e-05
-  Primary solution summary: L2-norm      : 0.7955
-                            Max value    : 0.9689
-                            Min value    : -0.009713
-                            Range        : 1.01
+  L2-norm            : 0.7955
+  Max value          : 0.9689
+  Min value          : -0.009713
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0550597
   Solving the elasto-dynamics problem...
   step=50  time=2.5e-05
@@ -1324,10 +1324,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 2.706 0.002365
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2724
   Solving crack phase field at step=50 time=2.5e-05
-  Primary solution summary: L2-norm      : 0.7951
-                            Max value    : 0.9689
-                            Min value    : -0.009659
-                            Range        : 1.01
+  L2-norm            : 0.7951
+  Max value          : 0.9689
+  Min value          : -0.009659
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.055583
   >>> Paused for mesh refinement at time=2.5e-05
   Lowest element:      ...    |c| = 3.954e-05
@@ -1351,10 +1351,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 2.898 0.002682
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2759
   Solving crack phase field at step=51 time=2.55e-05
-  Primary solution summary: L2-norm      : 0.7947
-                            Max value    : 0.9689
-                            Min value    : -0.00963
-                            Range        : 1.01
+  L2-norm            : 0.7947
+  Max value          : 0.9689
+  Min value          : -0.00963
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0560531
   Solving the elasto-dynamics problem...
   step=52  time=2.6e-05
@@ -1372,10 +1372,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 3.108 0.002967
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2798
   Solving crack phase field at step=52 time=2.6e-05
-  Primary solution summary: L2-norm      : 0.7944
-                            Max value    : 0.9689
-                            Min value    : -0.009611
-                            Range        : 1.01
+  L2-norm            : 0.7944
+  Max value          : 0.9689
+  Min value          : -0.009611
+  Range              : 1.01
   Dissipated energy:               eps_d : 0.0564948
   >>> Paused for mesh refinement at time=2.6e-05
   Lowest element:      ...    |c| = 2.133e-05
@@ -1399,10 +1399,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 3.337 0.003254
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2838
   Solving crack phase field at step=53 time=2.65e-05
-  Primary solution summary: L2-norm      : 0.794
-                            Max value    : 0.9689
-                            Min value    : -0.009446
-                            Range        : 1.009
+  L2-norm            : 0.794
+  Max value          : 0.9689
+  Min value          : -0.009446
+  Range              : 1.009
   Dissipated energy:               eps_d : 0.0569325
   Solving the elasto-dynamics problem...
   step=54  time=2.7e-05
@@ -1420,10 +1420,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 3.59 0.003477
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2882
   Solving crack phase field at step=54 time=2.7e-05
-  Primary solution summary: L2-norm      : 0.7935
-                            Max value    : 0.9689
-                            Min value    : -0.008863
-                            Range        : 1.009
+  L2-norm            : 0.7935
+  Max value          : 0.9689
+  Min value          : -0.008863
+  Range              : 1.009
   Dissipated energy:               eps_d : 0.0574268
   >>> Paused for mesh refinement at time=2.7e-05
   Lowest element:      ...    |c| = 2.954e-05
@@ -1447,10 +1447,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 3.866 0.003633
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2929
   Solving crack phase field at step=55 time=2.75e-05
-  Primary solution summary: L2-norm      : 0.7929
-                            Max value    : 0.9689
-                            Min value    : -0.008238
-                            Range        : 1.008
+  L2-norm            : 0.7929
+  Max value          : 0.9689
+  Min value          : -0.008238
+  Range              : 1.008
   Dissipated energy:               eps_d : 0.0579888
   Solving the elasto-dynamics problem...
   step=56  time=2.8e-05
@@ -1468,10 +1468,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 4.162 0.003715
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.298
   Solving crack phase field at step=56 time=2.8e-05
-  Primary solution summary: L2-norm      : 0.7923
-                            Max value    : 0.9689
-                            Min value    : -0.007673
-                            Range        : 1.008
+  L2-norm            : 0.7923
+  Max value          : 0.9689
+  Min value          : -0.007673
+  Range              : 1.008
   Dissipated energy:               eps_d : 0.0586149
   >>> Paused for mesh refinement at time=2.8e-05
   Lowest element:      ...    |c| = 1.861e-05
@@ -1495,10 +1495,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 4.464 0.003758
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3037
   Solving crack phase field at step=57 time=2.85e-05
-  Primary solution summary: L2-norm      : 0.7915
-                            Max value    : 0.9689
-                            Min value    : -0.007217
-                            Range        : 1.007
+  L2-norm            : 0.7915
+  Max value          : 0.9689
+  Min value          : -0.007217
+  Range              : 1.007
   Dissipated energy:               eps_d : 0.0593183
   Solving the elasto-dynamics problem...
   step=58  time=2.9e-05
@@ -1516,10 +1516,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 4.754 0.003732
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3096
   Solving crack phase field at step=58 time=2.9e-05
-  Primary solution summary: L2-norm      : 0.7907
-                            Max value    : 0.9689
-                            Min value    : -0.006863
-                            Range        : 1.007
+  L2-norm            : 0.7907
+  Max value          : 0.9689
+  Min value          : -0.006863
+  Range              : 1.007
   Dissipated energy:               eps_d : 0.0601237
   >>> Paused for mesh refinement at time=2.9e-05
   Lowest element:      ...    |c| = 4.171e-05
@@ -1543,10 +1543,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 5.034 0.003698
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3156
   Solving crack phase field at step=59 time=2.95e-05
-  Primary solution summary: L2-norm      : 0.7898
-                            Max value    : 0.9689
-                            Min value    : -0.006658
-                            Range        : 1.007
+  L2-norm            : 0.7898
+  Max value          : 0.9689
+  Min value          : -0.006658
+  Range              : 1.007
   Dissipated energy:               eps_d : 0.0610461
   Solving the elasto-dynamics problem...
   step=60  time=3e-05
@@ -1564,10 +1564,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 5.323 0.003664
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3215
   Solving crack phase field at step=60 time=3e-05
-  Primary solution summary: L2-norm      : 0.7888
-                            Max value    : 0.9689
-                            Min value    : -0.006503
-                            Range        : 1.007
+  L2-norm            : 0.7888
+  Max value          : 0.9689
+  Min value          : -0.006503
+  Range              : 1.007
   Dissipated energy:               eps_d : 0.0620755
   >>> Paused for mesh refinement at time=3e-05
   Lowest element:      ...    |c| = 1.432e-05
@@ -1591,10 +1591,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 5.637 0.003626
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3272
   Solving crack phase field at step=61 time=3.05e-05
-  Primary solution summary: L2-norm      : 0.7878
-                            Max value    : 0.9689
-                            Min value    : -0.006367
-                            Range        : 1.006
+  L2-norm            : 0.7878
+  Max value          : 0.9689
+  Min value          : -0.006367
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.0631674
   Solving the elasto-dynamics problem...
   step=62  time=3.1e-05
@@ -1612,10 +1612,10 @@ Number of unknowns    297
   Tensile & compressive energies         : 5.99 0.003566
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3327
   Solving crack phase field at step=62 time=3.1e-05
-  Primary solution summary: L2-norm      : 0.7869
-                            Max value    : 0.9689
-                            Min value    : -0.006264
-                            Range        : 1.006
+  L2-norm            : 0.7869
+  Max value          : 0.9689
+  Min value          : -0.006264
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.0642975
   >>> Paused for mesh refinement at time=3.1e-05
   Lowest element:      ...    |c| = 9.319e-05
@@ -1707,10 +1707,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 5.635 0.003625
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3272
   Solving crack phase field at step=61 time=3.05e-05
-  Primary solution summary: L2-norm      : 0.7728
-                            Max value    : 0.9689
-                            Min value    : -0.006365
-                            Range        : 1.006
+  L2-norm            : 0.7728
+  Max value          : 0.9689
+  Min value          : -0.006365
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.0631936
   Solving the elasto-dynamics problem...
   step=62  time=3.1e-05
@@ -1728,10 +1728,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 5.989 0.003567
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3327
   Solving crack phase field at step=62 time=3.1e-05
-  Primary solution summary: L2-norm      : 0.7708
-                            Max value    : 0.9689
-                            Min value    : -0.006425
-                            Range        : 1.006
+  L2-norm            : 0.7708
+  Max value          : 0.9689
+  Min value          : -0.006425
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.06447
   Solving the elasto-dynamics problem...
   step=63  time=3.15e-05
@@ -1749,10 +1749,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 6.403 0.003452
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3383
   Solving crack phase field at step=63 time=3.15e-05
-  Primary solution summary: L2-norm      : 0.7694
-                            Max value    : 0.9689
-                            Min value    : -0.006405
-                            Range        : 1.006
+  L2-norm            : 0.7694
+  Max value          : 0.9689
+  Min value          : -0.006405
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.065517
   >>> Paused for mesh refinement at time=3.15e-05
   Lowest element:      ...    |c| = 5.44e-05
@@ -1776,10 +1776,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 6.895 0.003294
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3439
   Solving crack phase field at step=64 time=3.2e-05
-  Primary solution summary: L2-norm      : 0.7679
-                            Max value    : 0.9689
-                            Min value    : -0.006299
-                            Range        : 1.006
+  L2-norm            : 0.7679
+  Max value          : 0.9689
+  Min value          : -0.006299
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.0666797
   Solving the elasto-dynamics problem...
   step=65  time=3.25e-05
@@ -1797,10 +1797,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 7.475 0.003064
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3496
   Solving crack phase field at step=65 time=3.25e-05
-  Primary solution summary: L2-norm      : 0.7664
-                            Max value    : 0.9689
-                            Min value    : -0.006127
-                            Range        : 1.006
+  L2-norm            : 0.7664
+  Max value          : 0.9689
+  Min value          : -0.006127
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.067796
   >>> Paused for mesh refinement at time=3.25e-05
   Lowest element:      ...    |c| = 9.268e-05
@@ -1824,10 +1824,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 8.148 0.002786
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3554
   Solving crack phase field at step=66 time=3.3e-05
-  Primary solution summary: L2-norm      : 0.7648
-                            Max value    : 0.9689
-                            Min value    : -0.005894
-                            Range        : 1.006
+  L2-norm            : 0.7648
+  Max value          : 0.9689
+  Min value          : -0.005894
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.0689574
   Solving the elasto-dynamics problem...
   step=67  time=3.35e-05
@@ -1845,10 +1845,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 8.905 0.002498
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3612
   Solving crack phase field at step=67 time=3.35e-05
-  Primary solution summary: L2-norm      : 0.7633
-                            Max value    : 0.9689
-                            Min value    : -0.005625
-                            Range        : 1.006
+  L2-norm            : 0.7633
+  Max value          : 0.9689
+  Min value          : -0.005625
+  Range              : 1.006
   Dissipated energy:               eps_d : 0.0701273
   >>> Paused for mesh refinement at time=3.35e-05
   Lowest element:      ...    |c| = 5.424e-05
@@ -1872,10 +1872,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 9.721 0.002202
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3672
   Solving crack phase field at step=68 time=3.4e-05
-  Primary solution summary: L2-norm      : 0.7617
-                            Max value    : 0.9689
-                            Min value    : -0.005399
-                            Range        : 1.005
+  L2-norm            : 0.7617
+  Max value          : 0.9689
+  Min value          : -0.005399
+  Range              : 1.005
   Dissipated energy:               eps_d : 0.0713103
   Solving the elasto-dynamics problem...
   step=69  time=3.45e-05
@@ -1893,10 +1893,10 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 10.58 0.001936
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3732
   Solving crack phase field at step=69 time=3.45e-05
-  Primary solution summary: L2-norm      : 0.7602
-                            Max value    : 0.9689
-                            Min value    : -0.00522
-                            Range        : 1.005
+  L2-norm            : 0.7602
+  Max value          : 0.9689
+  Min value          : -0.00522
+  Range              : 1.005
   Dissipated energy:               eps_d : 0.0725014
   >>> Paused for mesh refinement at time=3.45e-05
   Lowest element:      ...    |c| = 9.499e-05
@@ -1920,9 +1920,9 @@ Transferring 1088 history variables to new mesh for CahnHilliard
   Tensile & compressive energies         : 11.47 0.001772
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.3794
   Solving crack phase field at step=70 time=3.5e-05
-  Primary solution summary: L2-norm      : 0.7587
-                            Max value    : 0.9689
-                            Min value    : -0.005022
-                            Range        : 1.005
+  L2-norm            : 0.7587
+  Max value          : 0.9689
+  Min value          : -0.005022
+  Range              : 1.005
   Dissipated energy:               eps_d : 0.0737031
   Time integration completed.

--- a/Test/Short10x20_FD.reg
+++ b/Test/Short10x20_FD.reg
@@ -96,8 +96,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.00116572 4.96996e-06
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.0582174
   Solving crack phase field at step=1 time=1e-06
-  Primary solution summary: L2-norm      : 0.940816
-                            Max value    : 0.999068
+  L2-norm            : 0.940816
+  Max value          : 0.999068
   Dissipated energy:               eps_d : 0.0501864
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0264183
   Normalized L2-norm: |c^h|/V^0.5 : 0.934029
@@ -116,8 +116,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.00367373 4.29614e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.0902768
   Solving crack phase field at step=2 time=2e-06
-  Primary solution summary: L2-norm      : 0.936106
-                            Max value    : 0.997728
+  L2-norm            : 0.936106
+  Max value          : 0.997728
   Dissipated energy:               eps_d : 0.0502431
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0262959
   Normalized L2-norm: |c^h|/V^0.5 : 0.9297
@@ -136,8 +136,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.00559512 0.000124446
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.111527
   Solving crack phase field at step=3 time=3e-06
-  Primary solution summary: L2-norm      : 0.931711
-                            Max value    : 0.995272
+  L2-norm            : 0.931711
+  Max value          : 0.995272
   Dissipated energy:               eps_d : 0.0503091
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0261691
   Normalized L2-norm: |c^h|/V^0.5 : 0.925217
@@ -156,8 +156,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.00782489 0.000272082
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.130802
   Solving crack phase field at step=4 time=4e-06
-  Primary solution summary: L2-norm      : 0.927454
-                            Max value    : 0.991632
+  L2-norm            : 0.927454
+  Max value          : 0.991632
   Dissipated energy:               eps_d : 0.0503772
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0260436
   Normalized L2-norm: |c^h|/V^0.5 : 0.920782
@@ -177,8 +177,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.0101843 0.000523577
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.147458
   Solving crack phase field at step=5 time=5e-06
-  Primary solution summary: L2-norm      : 0.923384
-                            Max value    : 0.986297
+  L2-norm            : 0.923384
+  Max value          : 0.986297
   Dissipated energy:               eps_d : 0.0504568
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0259245
   Normalized L2-norm: |c^h|/V^0.5 : 0.91657
@@ -198,8 +198,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.0145137 0.000848453
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.162379
   Solving crack phase field at step=6 time=6e-06
-  Primary solution summary: L2-norm      : 0.91956
-                            Max value    : 0.973165
+  L2-norm            : 0.91956
+  Max value          : 0.973165
   Dissipated energy:               eps_d : 0.0505896
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0258148
   Normalized L2-norm: |c^h|/V^0.5 : 0.91269
@@ -219,8 +219,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.027071 0.00115247
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.176561
   Solving crack phase field at step=7 time=7e-06
-  Primary solution summary: L2-norm      : 0.91496
-                            Max value    : 0.973119
+  L2-norm            : 0.91496
+  Max value          : 0.973119
   Dissipated energy:               eps_d : 0.0509527
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0256839
   Normalized L2-norm: |c^h|/V^0.5 : 0.908062
@@ -240,8 +240,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.0557282 0.00133775
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.18975
   Solving crack phase field at step=8 time=8e-06
-  Primary solution summary: L2-norm      : 0.909601
-                            Max value    : 0.973097
+  L2-norm            : 0.909601
+  Max value          : 0.973097
   Dissipated energy:               eps_d : 0.0517534
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0255306
   Normalized L2-norm: |c^h|/V^0.5 : 0.902642
@@ -261,8 +261,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.0986279 0.00138685
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.202497
   Solving crack phase field at step=9 time=9e-06
-  Primary solution summary: L2-norm      : 0.903615
-                            Max value    : 0.97305
+  L2-norm            : 0.903615
+  Max value          : 0.97305
   Dissipated energy:               eps_d : 0.0529476
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0253581
   Normalized L2-norm: |c^h|/V^0.5 : 0.896544
@@ -282,8 +282,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.143066 0.00138235
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.215011
   Solving crack phase field at step=10 time=1e-05
-  Primary solution summary: L2-norm      : 0.896794
-                            Max value    : 0.97296
+  L2-norm            : 0.896794
+  Max value          : 0.97296
   Dissipated energy:               eps_d : 0.0543446
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.02516
   Normalized L2-norm: |c^h|/V^0.5 : 0.889541
@@ -303,8 +303,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.184928 0.00139236
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.227266
   Solving crack phase field at step=11 time=1.1e-05
-  Primary solution summary: L2-norm      : 0.889654
-                            Max value    : 0.972809
+  L2-norm            : 0.889654
+  Max value          : 0.972809
   Dissipated energy:               eps_d : 0.0559299
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0249501
   Normalized L2-norm: |c^h|/V^0.5 : 0.882121
@@ -324,8 +324,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.233607 0.00136027
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.239186
   Solving crack phase field at step=12 time=1.2e-05
-  Primary solution summary: L2-norm      : 0.88312
-                            Max value    : 0.972708
+  L2-norm            : 0.88312
+  Max value          : 0.972708
   Dissipated energy:               eps_d : 0.057805
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0247564
   Normalized L2-norm: |c^h|/V^0.5 : 0.875272
@@ -345,8 +345,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.297724 0.00126376
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.2503
   Solving crack phase field at step=13 time=1.3e-05
-  Primary solution summary: L2-norm      : 0.877742
-                            Max value    : 0.972572
+  L2-norm            : 0.877742
+  Max value          : 0.972572
   Dissipated energy:               eps_d : 0.0600418
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0245945
   Normalized L2-norm: |c^h|/V^0.5 : 0.869549
@@ -366,8 +366,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.376224 0.00119069
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.260104
   Solving crack phase field at step=14 time=1.4e-05
-  Primary solution summary: L2-norm      : 0.873329
-                            Max value    : 0.972463
+  L2-norm            : 0.873329
+  Max value          : 0.972463
   Dissipated energy:               eps_d : 0.0625822
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0244622
   Normalized L2-norm: |c^h|/V^0.5 : 0.864871
@@ -387,8 +387,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.465011 0.00123666
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.268291
   Solving crack phase field at step=15 time=1.5e-05
-  Primary solution summary: L2-norm      : 0.869301
-                            Max value    : 0.97233
+  L2-norm            : 0.869301
+  Max value          : 0.97233
   Dissipated energy:               eps_d : 0.0652587
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0243426
   Normalized L2-norm: |c^h|/V^0.5 : 0.86064
@@ -408,8 +408,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.567666 0.00140625
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.274945
   Solving crack phase field at step=16 time=1.6e-05
-  Primary solution summary: L2-norm      : 0.865983
-                            Max value    : 0.972327
+  L2-norm            : 0.865983
+  Max value          : 0.972327
   Dissipated energy:               eps_d : 0.067975
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0242434
   Normalized L2-norm: |c^h|/V^0.5 : 0.857133
@@ -429,8 +429,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.692145 0.00163937
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.280694
   Solving crack phase field at step=17 time=1.7e-05
-  Primary solution summary: L2-norm      : 0.863292
-                            Max value    : 0.972323
+  L2-norm            : 0.863292
+  Max value          : 0.972323
   Dissipated energy:               eps_d : 0.0707234
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0241617
   Normalized L2-norm: |c^h|/V^0.5 : 0.854244
@@ -450,8 +450,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 0.843271 0.00179882
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.286372
   Solving crack phase field at step=18 time=1.8e-05
-  Primary solution summary: L2-norm      : 0.861196
-                            Max value    : 0.972321
+  L2-norm            : 0.861196
+  Max value          : 0.972321
   Dissipated energy:               eps_d : 0.07339
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0240961
   Normalized L2-norm: |c^h|/V^0.5 : 0.851925
@@ -471,8 +471,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 1.02216 0.00169502
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.292492
   Solving crack phase field at step=19 time=1.9e-05
-  Primary solution summary: L2-norm      : 0.859641
-                            Max value    : 0.972318
+  L2-norm            : 0.859641
+  Max value          : 0.972318
   Dissipated energy:               eps_d : 0.0758357
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0240458
   Normalized L2-norm: |c^h|/V^0.5 : 0.850148
@@ -492,8 +492,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 1.2275 0.00129342
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.29899
   Solving crack phase field at step=20 time=2e-05
-  Primary solution summary: L2-norm      : 0.858485
-                            Max value    : 0.972316
+  L2-norm            : 0.858485
+  Max value          : 0.972316
   Dissipated energy:               eps_d : 0.0779698
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0240077
   Normalized L2-norm: |c^h|/V^0.5 : 0.848799
@@ -513,8 +513,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 1.4554 0.000830674
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.305499
   Solving crack phase field at step=21 time=2.1e-05
-  Primary solution summary: L2-norm      : 0.857657
-                            Max value    : 0.972314
+  L2-norm            : 0.857657
+  Max value          : 0.972314
   Dissipated energy:               eps_d : 0.0797355
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0239798
   Normalized L2-norm: |c^h|/V^0.5 : 0.847814
@@ -534,8 +534,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 1.70239 0.000565718
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.311889
   Solving crack phase field at step=22 time=2.2e-05
-  Primary solution summary: L2-norm      : 0.857026
-                            Max value    : 0.972312
+  L2-norm            : 0.857026
+  Max value          : 0.972312
   Dissipated energy:               eps_d : 0.0812027
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0239584
   Normalized L2-norm: |c^h|/V^0.5 : 0.847057
@@ -555,8 +555,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 1.97013 0.000454279
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.318441
   Solving crack phase field at step=23 time=2.3e-05
-  Primary solution summary: L2-norm      : 0.856488
-                            Max value    : 0.972311
+  L2-norm            : 0.856488
+  Max value          : 0.972311
   Dissipated energy:               eps_d : 0.0825027
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.02394
   Normalized L2-norm: |c^h|/V^0.5 : 0.846408
@@ -576,8 +576,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 2.26804 0.000374949
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.325527
   Solving crack phase field at step=24 time=2.4e-05
-  Primary solution summary: L2-norm      : 0.855939
-                            Max value    : 0.972309
+  L2-norm            : 0.855939
+  Max value          : 0.972309
   Dissipated energy:               eps_d : 0.0838064
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0239212
   Normalized L2-norm: |c^h|/V^0.5 : 0.845743
@@ -597,8 +597,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 2.61274 0.000343424
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.333276
   Solving crack phase field at step=25 time=2.5e-05
-  Primary solution summary: L2-norm      : 0.855331
-                            Max value    : 0.972308
+  L2-norm            : 0.855331
+  Max value          : 0.972308
   Dissipated energy:               eps_d : 0.0852042
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0239004
   Normalized L2-norm: |c^h|/V^0.5 : 0.845008
@@ -618,8 +618,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 3.01971 0.00042816
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.341623
   Solving crack phase field at step=26 time=2.6e-05
-  Primary solution summary: L2-norm      : 0.854651
-                            Max value    : 0.972307
+  L2-norm            : 0.854651
+  Max value          : 0.972307
   Dissipated energy:               eps_d : 0.0867075
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0238773
   Normalized L2-norm: |c^h|/V^0.5 : 0.844191
@@ -639,8 +639,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 3.49095 0.000682689
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.350568
   Solving crack phase field at step=27 time=2.7e-05
-  Primary solution summary: L2-norm      : 0.853948
-                            Max value    : 0.972306
+  L2-norm            : 0.853948
+  Max value          : 0.972306
   Dissipated energy:               eps_d : 0.088225
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0238536
   Normalized L2-norm: |c^h|/V^0.5 : 0.843352
@@ -660,8 +660,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 4.01094 0.00109374
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.360217
   Solving crack phase field at step=28 time=2.8e-05
-  Primary solution summary: L2-norm      : 0.853317
-                            Max value    : 0.972306
+  L2-norm            : 0.853317
+  Max value          : 0.972306
   Dissipated energy:               eps_d : 0.0896254
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0238322
   Normalized L2-norm: |c^h|/V^0.5 : 0.842597
@@ -681,8 +681,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 4.56543 0.00142443
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.370576
   Solving crack phase field at step=29 time=2.9e-05
-  Primary solution summary: L2-norm      : 0.852731
-                            Max value    : 0.972305
+  L2-norm            : 0.852731
+  Max value          : 0.972305
   Dissipated energy:               eps_d : 0.0909182
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0238124
   Normalized L2-norm: |c^h|/V^0.5 : 0.841897
@@ -702,8 +702,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 5.16542 0.00150086
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.381488
   Solving crack phase field at step=30 time=3e-05
-  Primary solution summary: L2-norm      : 0.85214
-                            Max value    : 0.972304
+  L2-norm            : 0.85214
+  Max value          : 0.972304
   Dissipated energy:               eps_d : 0.0921776
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0237926
   Normalized L2-norm: |c^h|/V^0.5 : 0.841195
@@ -723,8 +723,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 5.84366 0.00134701
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.392752
   Solving crack phase field at step=31 time=3.1e-05
-  Primary solution summary: L2-norm      : 0.851515
-                            Max value    : 0.972304
+  L2-norm            : 0.851515
+  Max value          : 0.972304
   Dissipated energy:               eps_d : 0.0934854
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0237718
   Normalized L2-norm: |c^h|/V^0.5 : 0.840459
@@ -744,8 +744,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 6.6393 0.00115883
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.404231
   Solving crack phase field at step=32 time=3.2e-05
-  Primary solution summary: L2-norm      : 0.850831
-                            Max value    : 0.972303
+  L2-norm            : 0.850831
+  Max value          : 0.972303
   Dissipated energy:               eps_d : 0.0948991
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0237492
   Normalized L2-norm: |c^h|/V^0.5 : 0.83966
@@ -765,8 +765,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 7.58735 0.00105656
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.415854
   Solving crack phase field at step=33 time=3.3e-05
-  Primary solution summary: L2-norm      : 0.850038
-                            Max value    : 0.972303
+  L2-norm            : 0.850038
+  Max value          : 0.972303
   Dissipated energy:               eps_d : 0.0964496
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0237235
   Normalized L2-norm: |c^h|/V^0.5 : 0.838754
@@ -786,8 +786,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 8.71175 0.000995969
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.427602
   Solving crack phase field at step=34 time=3.4e-05
-  Primary solution summary: L2-norm      : 0.849208
-                            Max value    : 0.972302
+  L2-norm            : 0.849208
+  Max value          : 0.972302
   Dissipated energy:               eps_d : 0.0980598
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.023697
   Normalized L2-norm: |c^h|/V^0.5 : 0.837815
@@ -807,8 +807,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 10.0218 0.000927656
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.439512
   Solving crack phase field at step=35 time=3.5e-05
-  Primary solution summary: L2-norm      : 0.848349
-                            Max value    : 0.972302
+  L2-norm            : 0.848349
+  Max value          : 0.972302
   Dissipated energy:               eps_d : 0.0996851
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0236699
   Normalized L2-norm: |c^h|/V^0.5 : 0.836856
@@ -828,8 +828,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 11.5027 0.000836689
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.451709
   Solving crack phase field at step=36 time=3.6e-05
-  Primary solution summary: L2-norm      : 0.847446
-                            Max value    : 0.972301
+  L2-norm            : 0.847446
+  Max value          : 0.972301
   Dissipated energy:               eps_d : 0.10131
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0236419
   Normalized L2-norm: |c^h|/V^0.5 : 0.835867
@@ -849,8 +849,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 13.0971 0.000742803
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.464418
   Solving crack phase field at step=37 time=3.7e-05
-  Primary solution summary: L2-norm      : 0.846434
-                            Max value    : 0.972301
+  L2-norm            : 0.846434
+  Max value          : 0.972301
   Dissipated energy:               eps_d : 0.102965
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0236117
   Normalized L2-norm: |c^h|/V^0.5 : 0.834801
@@ -870,8 +870,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 14.7617 0.000638539
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.477889
   Solving crack phase field at step=38 time=3.8e-05
-  Primary solution summary: L2-norm      : 0.845323
-                            Max value    : 0.972301
+  L2-norm            : 0.845323
+  Max value          : 0.972301
   Dissipated energy:               eps_d : 0.104652
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0235799
   Normalized L2-norm: |c^h|/V^0.5 : 0.833675
@@ -891,8 +891,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 16.5067 0.000608618
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.492244
   Solving crack phase field at step=39 time=3.9e-05
-  Primary solution summary: L2-norm      : 0.844205
-                            Max value    : 0.9723
+  L2-norm            : 0.844205
+  Max value          : 0.9723
   Dissipated energy:               eps_d : 0.106327
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0235483
   Normalized L2-norm: |c^h|/V^0.5 : 0.832559
@@ -912,8 +912,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 18.3603 0.000649037
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.507409
   Solving crack phase field at step=40 time=4e-05
-  Primary solution summary: L2-norm      : 0.843203
-                            Max value    : 0.9723
+  L2-norm            : 0.843203
+  Max value          : 0.9723
   Dissipated energy:               eps_d : 0.107903
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0235204
   Normalized L2-norm: |c^h|/V^0.5 : 0.83157
@@ -933,8 +933,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 20.3634 0.000689594
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.523164
   Solving crack phase field at step=41 time=4.1e-05
-  Primary solution summary: L2-norm      : 0.842348
-                            Max value    : 0.9723
+  L2-norm            : 0.842348
+  Max value          : 0.9723
   Dissipated energy:               eps_d : 0.109337
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0234967
   Normalized L2-norm: |c^h|/V^0.5 : 0.830733
@@ -954,8 +954,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 22.5703 0.000705389
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.539198
   Solving crack phase field at step=42 time=4.2e-05
-  Primary solution summary: L2-norm      : 0.841616
-                            Max value    : 0.9723
+  L2-norm            : 0.841616
+  Max value          : 0.9723
   Dissipated energy:               eps_d : 0.110629
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0234766
   Normalized L2-norm: |c^h|/V^0.5 : 0.830024
@@ -975,8 +975,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 25.0374 0.000721346
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.555175
   Solving crack phase field at step=43 time=4.3e-05
-  Primary solution summary: L2-norm      : 0.840886
-                            Max value    : 0.9723
+  L2-norm            : 0.840886
+  Max value          : 0.9723
   Dissipated energy:               eps_d : 0.111859
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0234574
   Normalized L2-norm: |c^h|/V^0.5 : 0.829345
@@ -996,8 +996,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 27.8295 0.000589983
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.570865
   Solving crack phase field at step=44 time=4.4e-05
-  Primary solution summary: L2-norm      : 0.840024
-                            Max value    : 0.971941
+  L2-norm            : 0.840024
+  Max value          : 0.971941
   Dissipated energy:               eps_d : 0.113111
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0234359
   Normalized L2-norm: |c^h|/V^0.5 : 0.828584
@@ -1017,8 +1017,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 31.0108 0.000477665
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.586263
   Solving crack phase field at step=45 time=4.5e-05
-  Primary solution summary: L2-norm      : 0.839249
-                            Max value    : 0.97194
+  L2-norm            : 0.839249
+  Max value          : 0.97194
   Dissipated energy:               eps_d : 0.114409
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0234169
   Normalized L2-norm: |c^h|/V^0.5 : 0.827913
@@ -1038,8 +1038,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 34.62 0.00040002
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.60157
   Solving crack phase field at step=46 time=4.6e-05
-  Primary solution summary: L2-norm      : 0.838515
-                            Max value    : 0.97194
+  L2-norm            : 0.838515
+  Max value          : 0.97194
   Dissipated energy:               eps_d : 0.115747
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0233993
   Normalized L2-norm: |c^h|/V^0.5 : 0.827289
@@ -1059,8 +1059,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 38.6628 0.000311994
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.617032
   Solving crack phase field at step=47 time=4.7e-05
-  Primary solution summary: L2-norm      : 0.837845
-                            Max value    : 0.97194
+  L2-norm            : 0.837845
+  Max value          : 0.97194
   Dissipated energy:               eps_d : 0.117056
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0233832
   Normalized L2-norm: |c^h|/V^0.5 : 0.826722
@@ -1080,8 +1080,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 43.1054 0.000298256
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.632825
   Solving crack phase field at step=48 time=4.8e-05
-  Primary solution summary: L2-norm      : 0.837295
-                            Max value    : 0.97194
+  L2-norm            : 0.837295
+  Max value          : 0.97194
   Dissipated energy:               eps_d : 0.11824
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0233699
   Normalized L2-norm: |c^h|/V^0.5 : 0.826251
@@ -1101,8 +1101,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 47.8752 0.000324526
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.64905
   Solving crack phase field at step=49 time=4.9e-05
-  Primary solution summary: L2-norm      : 0.836875
-                            Max value    : 0.97194
+  L2-norm            : 0.836875
+  Max value          : 0.97194
   Dissipated energy:               eps_d : 0.119244
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0233595
   Normalized L2-norm: |c^h|/V^0.5 : 0.825883
@@ -1122,8 +1122,8 @@ Number of unknowns    231
   Tensile & compressive energies         : 52.8748 0.000287044
   External energy: ((f,u^h)+(t,u^h))^0.5 : 0.665737
   Solving crack phase field at step=50 time=5e-05
-  Primary solution summary: L2-norm      : 0.836569
-                            Max value    : 0.97194
+  L2-norm            : 0.836569
+  Max value          : 0.97194
   Dissipated energy:               eps_d : 0.120054
   L2-norm: |c^h| = (c^h,c^h)^0.5  : 0.0233516
   Normalized L2-norm: |c^h|/V^0.5 : 0.825605

--- a/Test/Sneddon-200_FD.reg
+++ b/Test/Sneddon-200_FD.reg
@@ -89,9 +89,9 @@ Number of unknowns    40401
                             Max X-component : 1.80544e-05
                             Max Y-component : 0.000140278
   Total reaction forces:          Sum(R) : 0 0
-  Primary solution summary: L2-norm      : 0.998975
-                            Max value    : 1
-                            Min value    : -0.177113
-                            Range        : 1.17711
+  L2-norm            : 0.998975
+  Max value          : 1
+  Min value          : -0.177113
+  Range              : 1.17711
   Dissipated energy:               eps_d : 0.604389
   Time integration completed.

--- a/Test/Sneddon-unit_FDporo.reg
+++ b/Test/Sneddon-unit_FDporo.reg
@@ -68,10 +68,10 @@ Number of unknowns    484
 		sol2 =  9.55385e-03  1.28525e-02  9.28952e-04  9.55385e-03  1.28525e-02  4.64476e-04  2.25365e-02  0.00000e+00  0.00000e+00  0.00000e+00
 
   Solving crack phase field at step=1 time=250
-  Primary solution summary: L2-norm      : 0.787995
-                            Max value    : 0.912324
-                            Min value    : -0.0130768
-                            Range        : 1.01308
+  L2-norm            : 0.787995
+  Max value          : 0.912324
+  Min value          : -0.0130768
+  Range              : 1.01308
   Dissipated energy:               eps_d : 2.51044
   Solving the elasto-dynamics problem...
   step=2  time=500
@@ -89,10 +89,10 @@ Number of unknowns    484
 		sol2 =  2.82200e-02  4.30930e-02  3.06150e-03  2.82200e-02  4.30930e-02  1.53075e-03  7.16545e-02  4.30949e-04  0.00000e+00  0.00000e+00
 
   Solving crack phase field at step=2 time=500
-  Primary solution summary: L2-norm      : 0.787995
-                            Max value    : 0.912324
-                            Min value    : -0.0130767
-                            Range        : 1.01308
+  L2-norm            : 0.787995
+  Max value          : 0.912324
+  Min value          : -0.0130767
+  Range              : 1.01308
   Dissipated energy:               eps_d : 2.51044
   Solving the elasto-dynamics problem...
   step=3  time=750
@@ -110,8 +110,8 @@ Number of unknowns    484
 		sol2 =  4.60374e-02  7.29163e-02  5.10230e-03  4.60374e-02  7.29163e-02  2.55115e-03  1.19523e-01  7.28295e-04  0.00000e+00  0.00000e+00
 
   Solving crack phase field at step=3 time=750
-  Primary solution summary: L2-norm      : 0.787995
-                            Max value    : 0.912324
-                            Min value    : -0.0130767
-                            Range        : 1.01308
+  L2-norm            : 0.787995
+  Max value          : 0.912324
+  Min value          : -0.0130767
+  Range              : 1.01308
   Dissipated energy:               eps_d : 2.51044

--- a/Test/ts1-25x25-5P-adap2-relax-aitken_FD.reg
+++ b/Test/ts1-25x25-5P-adap2-relax-aitken_FD.reg
@@ -15,20 +15,20 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.00429432
                             Max X-component : 0.00837081
                             Max Y-component : 0.010632
-  Primary solution summary: L2-norm      : 0.999994
-                            Max value    : 1
-                            Min value    : 0.999664
-                            Range        : 0.000335897
+  L2-norm            : 0.999994
+  Max value          : 1
+  Min value          : 0.999664
+  Range              : 0.000335897
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -0.0646948
   Elastic strain energy:           eps_e : 0.0323474
   Bulk energy:                     eps_b : 0.0323473
   Tensile & compressive energies         : 0.0195707 0.0127782
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.179854
-  Primary solution summary: L2-norm      : 0.999994
-                            Max value    : 1
-                            Min value    : 0.999664
-                            Range        : 0.000335897
+  L2-norm            : 0.999994
+  Max value          : 1
+  Min value          : 0.999664
+  Range              : 0.000335897
   step=2  time=0.02
   Primary solution summary: L2-norm         : 0.00858863
                             Max X-component : 0.0167416
@@ -39,47 +39,47 @@ Number of unknowns    2025
   Bulk energy:                     eps_b : 0.129371
   Tensile & compressive energies         : 0.0782914 0.0511042
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.359695
-  Primary solution summary: L2-norm      : 0.999976
-                            Max value    : 1
-                            Min value    : 0.998658
-                            Range        : 0.00134308
+  L2-norm            : 0.999976
+  Max value          : 1
+  Min value          : 0.998658
+  Range              : 0.00134308
   Dissipated energy:               eps_d : 1.19187e-05
   step=3  time=0.03
   step=3  time=0.03
-  Primary solution summary: L2-norm      : 0.999946
-                            Max value    : 1
-                            Min value    : 0.99698
-                            Range        : 0.0030216
+  L2-norm            : 0.999946
+  Max value          : 1
+  Min value          : 0.99698
+  Range              : 0.0030216
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -0.582038
   Elastic strain energy:           eps_e : 0.291019
   Bulk energy:                     eps_b : 0.291014
   Tensile & compressive energies         : 0.176188 0.114952
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.539512
-  Primary solution summary: L2-norm      : 0.999946
-                            Max value    : 1
-                            Min value    : 0.99698
-                            Range        : 0.0030216
+  L2-norm            : 0.999946
+  Max value          : 1
+  Min value          : 0.99698
+  Range              : 0.0030216
   Dissipated energy:               eps_d : 6.03297e-05
   step=4  time=0.04
   Primary solution summary: L2-norm         : 0.017177
                             Max X-component : 0.0334802
                             Max Y-component : 0.0425284
   step=4  time=0.04
-  Primary solution summary: L2-norm      : 0.999905
-                            Max value    : 1
-                            Min value    : 0.994631
-                            Range        : 0.00537256
+  L2-norm            : 0.999905
+  Max value          : 1
+  Min value          : 0.994631
+  Range              : 0.00537256
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -1.0344
   Elastic strain energy:           eps_e : 0.517201
   Bulk energy:                     eps_b : 0.517185
   Tensile & compressive energies         : 0.313303 0.20428
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.719291
-  Primary solution summary: L2-norm      : 0.999905
-                            Max value    : 1
-                            Min value    : 0.994631
-                            Range        : 0.00537256
+  L2-norm            : 0.999905
+  Max value          : 1
+  Min value          : 0.994631
+  Range              : 0.00537256
   Dissipated energy:               eps_d : 0.000190672
   step=5  time=0.05
   Primary solution summary: L2-norm         : 0.0214711
@@ -87,96 +87,96 @@ Number of unknowns    2025
                             Max Y-component : 0.0531608
 
   step=5  time=0.05
-  Primary solution summary: L2-norm      : 0.999851
-                            Max value    : 1.00001
-                            Min value    : 0.991608
-                            Range        : 0.00839813
+  L2-norm            : 0.999851
+  Max value          : 1.00001
+  Min value          : 0.991608
+  Range              : 0.00839813
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -1.61558
   Elastic strain energy:           eps_e : 0.80779
   Bulk energy:                     eps_b : 0.807752
   Tensile & compressive energies         : 0.489697 0.319027
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.89902
-  Primary solution summary: L2-norm      : 0.999851
-                            Max value    : 1.00001
-                            Min value    : 0.991608
-                            Range        : 0.00839813
+  L2-norm            : 0.999851
+  Max value          : 1.00001
+  Min value          : 0.991608
+  Range              : 0.00839813
   Dissipated energy:               eps_d : 0.00046558
   step=6  time=0.06
-  Primary solution summary: L2-norm      : 0.999786
-                            Max value    : 1.00001
-                            Min value    : 0.987907
-                            Range        : 0.0121016
+  L2-norm            : 0.999786
+  Max value          : 1.00001
+  Min value          : 0.987907
+  Range              : 0.0121016
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -2.32525
   Elastic strain energy:           eps_e : 1.16263
   Bulk energy:                     eps_b : 1.16255
   Tensile & compressive energies         : 0.705449 0.459116
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.07869
-  Primary solution summary: L2-norm      : 0.999786
-                            Max value    : 1.00001
-                            Min value    : 0.987907
-                            Range        : 0.0121016
+  L2-norm            : 0.999786
+  Max value          : 1.00001
+  Min value          : 0.987907
+  Range              : 0.0121016
   Dissipated energy:               eps_d : 0.000965719
   step=7  time=0.07
   Primary solution summary: L2-norm         : 0.0300588
                             Max X-component : 0.0585786
                             Max Y-component : 0.0744262
   step=7  time=0.07
-  Primary solution summary: L2-norm      : 0.999708
-                            Max value    : 1.00001
-                            Min value    : 0.983524
-                            Range        : 0.0164872
+  L2-norm            : 0.999708
+  Max value          : 1.00001
+  Min value          : 0.983524
+  Range              : 0.0164872
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -3.16303
   Elastic strain energy:           eps_e : 1.58151
   Bulk energy:                     eps_b : 1.58137
   Tensile & compressive energies         : 0.960655 0.624452
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.25828
-  Primary solution summary: L2-norm      : 0.999708
-                            Max value    : 1.00001
-                            Min value    : 0.983524
-                            Range        : 0.0164872
+  L2-norm            : 0.999708
+  Max value          : 1.00001
+  Min value          : 0.983524
+  Range              : 0.0164872
   Dissipated energy:               eps_d : 0.00178993
   step=8  time=0.08
   Primary solution summary: L2-norm         : 0.0343524
                             Max X-component : 0.0669409
                             Max Y-component : 0.0850593
   step=8  time=0.08
-  Primary solution summary: L2-norm      : 0.999619
-                            Max value    : 1.00001
-                            Min value    : 0.978454
-                            Range        : 0.0215604
+  L2-norm            : 0.999619
+  Max value          : 1.00001
+  Min value          : 0.978454
+  Range              : 0.0215604
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -4.12843
   Elastic strain energy:           eps_e : 2.06421
   Bulk energy:                     eps_b : 2.06396
   Tensile & compressive energies         : 1.25543 0.814925
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.43778
-  Primary solution summary: L2-norm      : 0.999619
-                            Max value    : 1.00001
-                            Min value    : 0.978454
-                            Range        : 0.0215604
+  L2-norm            : 0.999619
+  Max value          : 1.00001
+  Min value          : 0.978454
+  Range              : 0.0215604
   Dissipated energy:               eps_d : 0.0030554
   step=9  time=0.09
   Primary solution summary: L2-norm         : 0.0386458
                             Max X-component : 0.0753006
                             Max Y-component : 0.0956927
   step=9  time=0.09
-  Primary solution summary: L2-norm      : 0.999518
-                            Max value    : 1.00002
-                            Min value    : 0.972691
-                            Range        : 0.0273278
+  L2-norm            : 0.999518
+  Max value          : 1.00002
+  Min value          : 0.972691
+  Range              : 0.0273278
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -5.22091
   Elastic strain energy:           eps_e : 2.61046
   Bulk energy:                     eps_b : 2.61006
   Tensile & compressive energies         : 1.58991 1.0304
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.61719
-  Primary solution summary: L2-norm      : 0.999518
-                            Max value    : 1.00002
-                            Min value    : 0.972691
-                            Range        : 0.0273278
+  L2-norm            : 0.999518
+  Max value          : 1.00002
+  Min value          : 0.972691
+  Range              : 0.0273278
   Dissipated energy:               eps_d : 0.00489791
   step=10  time=0.1
   cycle 1: Res = 0.0124029 + .*-14 = 0.0124029  E = 3.2199 + 0.00751144 = 3.22741  beta=45, omega=0.0524087
@@ -185,20 +185,20 @@ Number of unknowns    2025
                             Max X-component : 0.083657
                             Max Y-component : 0.106326
   step=10  time=0.1
-  Primary solution summary: L2-norm      : 0.999405
-                            Max value    : 1.00002
-                            Min value    : 0.965973
-                            Range        : 0.03405
+  L2-norm            : 0.999405
+  Max value          : 1.00002
+  Min value          : 0.965973
+  Range              : 0.03405
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -6.43979
   Elastic strain energy:           eps_e : 3.2199
   Bulk energy:                     eps_b : 3.21929
   Tensile & compressive energies         : 1.96426 1.27073
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.79648
-  Primary solution summary: L2-norm      : 0.999405
-                            Max value    : 1.00002
-                            Min value    : 0.965973
-                            Range        : 0.03405
+  L2-norm            : 0.999405
+  Max value          : 1.00002
+  Min value          : 0.965973
+  Range              : 0.03405
   Dissipated energy:               eps_d : 0.00751152
   step=11  time=0.11
   cycle 1: Res = 0.0176989 + .*-14 = 0.0176989  E = 3.89224 + 0.011016 = 3.90325  beta=45, omega=0.0529378
@@ -207,20 +207,20 @@ Number of unknowns    2025
                             Max X-component : 0.0920104
                             Max Y-component : 0.116961
   step=11  time=0.11
-  Primary solution summary: L2-norm      : 0.99928
-                            Max value    : 1.00003
-                            Min value    : 0.958709
-                            Range        : 0.0413188
+  L2-norm            : 0.99928
+  Max value          : 1.00003
+  Min value          : 0.958709
+  Range              : 0.0413188
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -7.78447
   Elastic strain energy:           eps_e : 3.89224
   Bulk energy:                     eps_b : 3.89135
   Tensile & compressive energies         : 2.37865 1.53575
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.97564
-  Primary solution summary: L2-norm      : 0.99928
-                            Max value    : 1.00003
-                            Min value    : 0.958709
-                            Range        : 0.0413188
+  L2-norm            : 0.99928
+  Max value          : 1.00003
+  Min value          : 0.958709
+  Range              : 0.0413188
   Dissipated energy:               eps_d : 0.0110161
   step=12  time=0.12
   cycle 1: Res = 0.0252263 + .*-14 = 0.0252263  E = 4.62707 + 0.0156312 = 4.6427  beta=45, omega=0.0535389
@@ -228,30 +228,30 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.0515237
                             Max X-component : 0.10036
                             Max Y-component : 0.127595
-  Primary solution summary: L2-norm      : 0.999144
-                            Max value    : 1.00003
-                            Min value    : 0.950706
-                            Range        : 0.049328
+  L2-norm            : 0.999144
+  Max value          : 1.00003
+  Min value          : 0.950706
+  Range              : 0.049328
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -9.25413
   Elastic strain energy:           eps_e : 4.62707
   Bulk energy:                     eps_b : 4.62582
   Tensile & compressive energies         : 2.83327 1.82528
   External energy: ((f,u^h)+(t,u^h))^0.5 : -2.15467
-  Primary solution summary: L2-norm      : 0.999144
-                            Max value    : 1.00003
-                            Min value    : 0.950706
-                            Range        : 0.049328
+  L2-norm            : 0.999144
+  Max value          : 1.00003
+  Min value          : 0.950706
+  Range              : 0.049328
   Dissipated energy:               eps_d : 0.0156315
   step=13  time=0.13
   cycle 1: Res = 0.0349688 + .*e-14 = 0.0349688  E = 5.42396 + 0.0215745 = 5.44553  beta=45, omega=0.0542096
   Primary solution summary: L2-norm         : 0.0558159
                             Max X-component : 0.108707
                             Max Y-component : 0.13823
-  Primary solution summary: L2-norm      : 0.998996
-                            Max value    : 1.00004
-                            Min value    : 0.94195
-                            Range        : 0.0580901
+  L2-norm            : 0.998996
+  Max value          : 1.00004
+  Min value          : 0.94195
+  Range              : 0.0580901
   cycle 2: Res = 0.0330738 + .*e-14 = 0.0330738  E = 5.42396 + 0.0215745 = 5.44553  beta=0.046153.*, omega=1.00032
   cycle 3: Res = 0.000140227 + .*e-14 = 0.000140227  E = 5.42396 + 0.0215751 = 5.44553  beta=0.590278, omega=1.00455
   cycle 4: Res = 0.00262968 + .*e-14 = 0.00262968  E = 5.42395 + 0.0215843 = 5.44553  beta=0.056693.*, omega=-0.0565833
@@ -261,18 +261,18 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.0558155
                             Max X-component : 0.108706
                             Max Y-component : 0.13823
-  Primary solution summary: L2-norm      : 0.998996
-                            Max value    : 1.00004
-                            Min value    : 0.941906
-                            Range        : 0.058134
+  L2-norm            : 0.998996
+  Max value          : 1.00004
+  Min value          : 0.941906
+  Range              : 0.058134
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -10.8479
   Elastic strain energy:           eps_e : 5.42395
   Bulk energy:                     eps_b : 5.42224
   Tensile & compressive energies         : 3.32835 2.13912
   External energy: ((f,u^h)+(t,u^h))^0.5 : -2.33354
-  Primary solution summary: L2-norm      : 0.998996
-                            Max value    : 1.00004
-                            Min value    : 0.941906
-                            Range        : 0.0581341
+  L2-norm            : 0.998996
+  Max value          : 1.00004
+  Min value          : 0.941906
+  Range              : 0.0581341
   Dissipated energy:               eps_d : 0.021585

--- a/Test/ts1-25x25-5P-adap2-relax_FD.reg
+++ b/Test/ts1-25x25-5P-adap2-relax_FD.reg
@@ -17,174 +17,174 @@ Number of unknowns    2025
                             Max X-component : 0.00837081
                             Max Y-component : 0.010632
   step=1  time=0.01
-  Primary solution summary: L2-norm      : 0.999994
-                            Max value    : 1
-                            Min value    : 0.999664
-                            Range        : 0.000335897
+  L2-norm            : 0.999994
+  Max value          : 1
+  Min value          : 0.999664
+  Range              : 0.000335897
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -0.0646948
   Elastic strain energy:           eps_e : 0.0323474
   Bulk energy:                     eps_b : 0.0323473
   Tensile & compressive energies         : 0.0195707 0.0127782
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.179854
-  Primary solution summary: L2-norm      : 0.999994
-                            Max value    : 1
-                            Min value    : 0.999664
-                            Range        : 0.000335897
+  L2-norm            : 0.999994
+  Max value          : 1
+  Min value          : 0.999664
+  Range              : 0.000335897
   step=2  time=0.02
   Primary solution summary: L2-norm         : 0.00858861
                             Max X-component : 0.0167413
                             Max Y-component : 0.021264
   step=2  time=0.02
-  Primary solution summary: L2-norm      : 0.999976
-                            Max value    : 1
-                            Min value    : 0.998658
-                            Range        : 0.00134308
+  L2-norm            : 0.999976
+  Max value          : 1
+  Min value          : 0.998658
+  Range              : 0.00134308
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -0.258743
   Elastic strain energy:           eps_e : 0.129372
   Bulk energy:                     eps_b : 0.129371
   Tensile & compressive energies         : 0.0782914 0.0511042
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.359695
-  Primary solution summary: L2-norm      : 0.999976
-                            Max value    : 1
-                            Min value    : 0.998658
-                            Range        : 0.00134308
+  L2-norm            : 0.999976
+  Max value          : 1
+  Min value          : 0.998658
+  Range              : 0.00134308
   Dissipated energy:               eps_d : 1.19187e-05
   step=3  time=0.03
   Primary solution summary: L2-norm         : 0.0128829
                             Max X-component : 0.0251112
                             Max Y-component : 0.0318962
   step=3  time=0.03
-  Primary solution summary: L2-norm      : 0.999946
-                            Max value    : 1
-                            Min value    : 0.99698
-                            Range        : 0.0030216
+  L2-norm            : 0.999946
+  Max value          : 1
+  Min value          : 0.99698
+  Range              : 0.0030216
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -0.582038
   Elastic strain energy:           eps_e : 0.291019
   Bulk energy:                     eps_b : 0.291014
   Tensile & compressive energies         : 0.176188 0.114952
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.539512
-  Primary solution summary: L2-norm      : 0.999946
-                            Max value    : 1
-                            Min value    : 0.99698
-                            Range        : 0.0030216
+  L2-norm            : 0.999946
+  Max value          : 1
+  Min value          : 0.99698
+  Range              : 0.0030216
   Dissipated energy:               eps_d : 6.03297e-05
   step=4  time=0.04
   Primary solution summary: L2-norm         : 0.017177
                             Max X-component : 0.0334802
                             Max Y-component : 0.0425284
-  Primary solution summary: L2-norm      : 0.999905
-                            Max value    : 1
-                            Min value    : 0.994631
-                            Range        : 0.00537256
+  L2-norm            : 0.999905
+  Max value          : 1
+  Min value          : 0.994631
+  Range              : 0.00537256
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -1.0344
   Elastic strain energy:           eps_e : 0.517201
   Bulk energy:                     eps_b : 0.517185
   Tensile & compressive energies         : 0.313303 0.20428
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.719291
-  Primary solution summary: L2-norm      : 0.999905
-                            Max value    : 1
-                            Min value    : 0.994631
-                            Range        : 0.00537256
+  L2-norm            : 0.999905
+  Max value          : 1
+  Min value          : 0.994631
+  Range              : 0.00537256
   Dissipated energy:               eps_d : 0.000190672
   step=5  time=0.05
   Primary solution summary: L2-norm         : 0.0214711
                             Max X-component : 0.041848
                             Max Y-component : 0.0531608
-  Primary solution summary: L2-norm      : 0.999851
-                            Max value    : 1.00001
-                            Min value    : 0.991608
-                            Range        : 0.00839813
+  L2-norm            : 0.999851
+  Max value          : 1.00001
+  Min value          : 0.991608
+  Range              : 0.00839813
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -1.61558
   Elastic strain energy:           eps_e : 0.80779
   Bulk energy:                     eps_b : 0.807752
   Tensile & compressive energies         : 0.489697 0.319027
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.89902
-  Primary solution summary: L2-norm      : 0.999851
-                            Max value    : 1.00001
-                            Min value    : 0.991608
-                            Range        : 0.00839813
+  L2-norm            : 0.999851
+  Max value          : 1.00001
+  Min value          : 0.991608
+  Range              : 0.00839813
   Dissipated energy:               eps_d : 0.00046558
   step=6  time=0.06
   Primary solution summary: L2-norm         : 0.025765
                             Max X-component : 0.0502142
                             Max Y-component : 0.0637934
-  Primary solution summary: L2-norm      : 0.999786
-                            Max value    : 1.00001
-                            Min value    : 0.987907
-                            Range        : 0.0121016
+  L2-norm            : 0.999786
+  Max value          : 1.00001
+  Min value          : 0.987907
+  Range              : 0.0121016
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -2.32525
   Elastic strain energy:           eps_e : 1.16263
   Bulk energy:                     eps_b : 1.16255
   Tensile & compressive energies         : 0.705449 0.459116
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.07869
-  Primary solution summary: L2-norm      : 0.999786
-                            Max value    : 1.00001
-                            Min value    : 0.987907
-                            Range        : 0.0121016
+  L2-norm            : 0.999786
+  Max value          : 1.00001
+  Min value          : 0.987907
+  Range              : 0.0121016
   Dissipated energy:               eps_d : 0.000965719
   step=7  time=0.07
   Primary solution summary: L2-norm         : 0.0300588
                             Max X-component : 0.0585786
                             Max Y-component : 0.0744262
-  Primary solution summary: L2-norm      : 0.999708
-                            Max value    : 1.00001
-                            Min value    : 0.983524
-                            Range        : 0.0164872
+  L2-norm            : 0.999708
+  Max value          : 1.00001
+  Min value          : 0.983524
+  Range              : 0.0164872
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -3.16303
   Elastic strain energy:           eps_e : 1.58151
   Bulk energy:                     eps_b : 1.58137
   Tensile & compressive energies         : 0.960655 0.624452
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.25828
-  Primary solution summary: L2-norm      : 0.999708
-                            Max value    : 1.00001
-                            Min value    : 0.983524
-                            Range        : 0.0164872
+  L2-norm            : 0.999708
+  Max value          : 1.00001
+  Min value          : 0.983524
+  Range              : 0.0164872
   Dissipated energy:               eps_d : 0.00178993
   step=8  time=0.08
   Primary solution summary: L2-norm         : 0.0343524
                             Max X-component : 0.0669409
                             Max Y-component : 0.0850593
-  Primary solution summary: L2-norm      : 0.999619
-                            Max value    : 1.00001
-                            Min value    : 0.978454
-                            Range        : 0.0215604
+  L2-norm            : 0.999619
+  Max value          : 1.00001
+  Min value          : 0.978454
+  Range              : 0.0215604
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -4.12843
   Elastic strain energy:           eps_e : 2.06421
   Bulk energy:                     eps_b : 2.06396
   Tensile & compressive energies         : 1.25543 0.814925
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.43778
-  Primary solution summary: L2-norm      : 0.999619
-                            Max value    : 1.00001
-                            Min value    : 0.978454
-                            Range        : 0.0215604
+  L2-norm            : 0.999619
+  Max value          : 1.00001
+  Min value          : 0.978454
+  Range              : 0.0215604
   Dissipated energy:               eps_d : 0.0030554
   step=9  time=0.09
   Primary solution summary: L2-norm         : 0.0386458
                             Max X-component : 0.0753006
                             Max Y-component : 0.0956927
 
-  Primary solution summary: L2-norm      : 0.999518
-                            Max value    : 1.00002
-                            Min value    : 0.972691
-                            Range        : 0.0273278
+  L2-norm            : 0.999518
+  Max value          : 1.00002
+  Min value          : 0.972691
+  Range              : 0.0273278
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -5.22091
   Elastic strain energy:           eps_e : 2.61046
   Bulk energy:                     eps_b : 2.61006
   Tensile & compressive energies         : 1.58991 1.0304
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.61719
-  Primary solution summary: L2-norm      : 0.999518
-                            Max value    : 1.00002
-                            Min value    : 0.972691
-                            Range        : 0.0273278
+  L2-norm            : 0.999518
+  Max value          : 1.00002
+  Min value          : 0.972691
+  Range              : 0.0273278
   Dissipated energy:               eps_d : 0.00489791
   step=10  time=0.1
   cycle 1: Res = 0.0124029 + .*e-14 = 0.0124029  E = 3.2199 + 0.00751144 = 3.22741  beta=45, omega=0.9
@@ -194,20 +194,20 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.0429387
                             Max X-component : 0.083657
                             Max Y-component : 0.106326
-  Primary solution summary: L2-norm      : 0.999405
-                            Max value    : 1.00002
-                            Min value    : 0.965962
-                            Range        : 0.034061
+  L2-norm            : 0.999405
+  Max value          : 1.00002
+  Min value          : 0.965962
+  Range              : 0.034061
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -6.43979
   Elastic strain energy:           eps_e : 3.21989
   Bulk energy:                     eps_b : 3.21929
   Tensile & compressive energies         : 1.96426 1.27073
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.79648
-  Primary solution summary: L2-norm      : 0.999405
-                            Max value    : 1.00002
-                            Min value    : 0.965962
-                            Range        : 0.034061
+  L2-norm            : 0.999405
+  Max value          : 1.00002
+  Min value          : 0.965962
+  Range              : 0.034061
   Dissipated energy:               eps_d : 0.00751303
   step=11  time=0.11
   cycle 1: Res = 0.0176667 + .*e-14 = 0.0176667  E = 3.89224 + 0.011016 = 3.90325  beta=45, omega=0.9
@@ -217,20 +217,20 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.0472314
                             Max X-component : 0.0920104
                             Max Y-component : 0.116961
-  Primary solution summary: L2-norm      : 0.99928
-                            Max value    : 1.00003
-                            Min value    : 0.958692
-                            Range        : 0.0413362
+  L2-norm            : 0.99928
+  Max value          : 1.00003
+  Min value          : 0.958692
+  Range              : 0.0413362
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -7.78447
   Elastic strain energy:           eps_e : 3.89223
   Bulk energy:                     eps_b : 3.89135
   Tensile & compressive energies         : 2.37865 1.53575
   External energy: ((f,u^h)+(t,u^h))^0.5 : -1.97564
-  Primary solution summary: L2-norm      : 0.99928
-                            Max value    : 1.00003
-                            Min value    : 0.958692
-                            Range        : 0.0413361
+  L2-norm            : 0.99928
+  Max value          : 1.00003
+  Min value          : 0.958692
+  Range              : 0.0413361
   Dissipated energy:               eps_d : 0.011019
   step=12  time=0.12
   cycle 0: Res = 0.361887 + .*e-14 = 0.361887  E = 4.62717 + 0.0155345 = 4.64271
@@ -242,20 +242,20 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.0515237
                             Max X-component : 0.10036
                             Max Y-component : 0.127595
-  Primary solution summary: L2-norm      : 0.999144
-                            Max value    : 1.00003
-                            Min value    : 0.950678
-                            Range        : 0.0493555
+  L2-norm            : 0.999144
+  Max value          : 1.00003
+  Min value          : 0.950678
+  Range              : 0.0493555
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -9.25412
   Elastic strain energy:           eps_e : 4.62706
   Bulk energy:                     eps_b : 4.62581
   Tensile & compressive energies         : 2.83327 1.82528
   External energy: ((f,u^h)+(t,u^h))^0.5 : -2.15467
-  Primary solution summary: L2-norm      : 0.999144
-                            Max value    : 1.00003
-                            Min value    : 0.950678
-                            Range        : 0.0493555
+  L2-norm            : 0.999144
+  Max value          : 1.00003
+  Min value          : 0.950678
+  Range              : 0.0493555
   Dissipated energy:               eps_d : 0.015637
   step=13  time=0.13
   cycle 0: Res = 0.426008 + .*e-14 = 0.426008  E = 5.42412 + 0.0214294 = 5.44554
@@ -267,18 +267,18 @@ Number of unknowns    2025
   Primary solution summary: L2-norm         : 0.0558155
                             Max X-component : 0.108706
                             Max Y-component : 0.13823
-  Primary solution summary: L2-norm      : 0.998996
-                            Max value    : 1.00004
-                            Min value    : 0.941906
-                            Range        : 0.0581339
+  L2-norm            : 0.998996
+  Max value          : 1.00004
+  Min value          : 0.941906
+  Range              : 0.0581339
   Total reaction forces:          Sum(R) : 0 0
   displacement\*reactions:          (R,u) : -10.8479
   Elastic strain energy:           eps_e : 5.42395
   Bulk energy:                     eps_b : 5.42224
   Tensile & compressive energies         : 3.32835 2.13912
   External energy: ((f,u^h)+(t,u^h))^0.5 : -2.33354
-  Primary solution summary: L2-norm      : 0.998996
-                            Max value    : 1.00004
-                            Min value    : 0.941906
-                            Range        : 0.0581338
+  L2-norm            : 0.998996
+  Max value          : 1.00004
+  Min value          : 0.941906
+  Range              : 0.0581338
   Dissipated energy:               eps_d : 0.0215849

--- a/Test/ts1-50x40-Miehe_FD.reg
+++ b/Test/ts1-50x40-Miehe_FD.reg
@@ -112,10 +112,10 @@ Loading initial condition for "phasefield" component 1
 from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(dY),sqrt(dX\*dX+dY\*dY)); 1.0-exp(-d/ell)
 100. Starting the simulation
   Initial phase field...
-  Primary solution summary: L2-norm      : 0.92325
-                            Max value    : 1
-                            Min value    : 0 node 1021
-                            Range        : 1
+  L2-norm            : 0.92325
+  Max value          : 1
+  Min value          : 0 node 1021
+  Range              : 1
   Dissipated energy:               eps_d : 0.00139208
   Solving the elasto-dynamics problem...
   step=1  time=0.01
@@ -127,36 +127,36 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Res = .*e-1. + 0.000539492 = 0.000539492
     E = 7.42007e-07 + 0.00139208 = 0.00139283
   step=2  time=0.2
-  Primary solution summary: L2-norm      : 0.922844
-                            Max value    : 0.99999
-                            Min value    : 0.00135326 node 1045
-                            Range        : 0.998647
+  L2-norm            : 0.922844
+  Max value          : 0.99999
+  Min value          : 0.00135326 node 1045
+  Range              : 0.998647
   Primary solution summary: L2-norm         : 0.000897138
                             Max X-component : 0.000713512
                             Max Y-component : 0.00204655
   cycle 0: Res = .*e-1. + 0.000120912 = 0.000120912  E = 0.00028641 + 0.00134996 = 0.00163637
-  Primary solution summary: L2-norm      : 0.922681
-                            Max value    : 0.99999
-                            Min value    : -0.000704127 node 1045
-                            Range        : 1.0007
+  L2-norm            : 0.922681
+  Max value          : 0.99999
+  Min value          : -0.000704127 node 1045
+  Range              : 1.0007
   step=2  time=0.2
   Primary solution summary: L2-norm         : 0.000901882
                             Max X-component : 0.000710166
                             Max Y-component : 0.00208052
   cycle 1: Res = .*e-1. + 4.74519e-05 = 4.74519e-05  E = 0.000280293 + 0.00135528 = 0.00163557  beta=45
-  Primary solution summary: L2-norm      : 0.922655
-                            Max value    : 0.999986
-                            Min value    : -0.000855338 node 1045
-                            Range        : 1.00086
+  L2-norm            : 0.922655
+  Max value          : 0.999986
+  Min value          : -0.000855338 node 1045
+  Range              : 1.00086
   step=2  time=0.2
   Primary solution summary: L2-norm         : 0.00090328
                             Max X-component : 0.000708608
                             Max Y-component : 0.00209011
   cycle 2: Res = .*e-1. + 1.53583e-05 = 1.53583e-05  E = 0.000278356 + 0.00135712 = 0.00163548  beta=11.9855
-  Primary solution summary: L2-norm      : 0.922647
-                            Max value    : 0.999984
-                            Min value    : -0.00088328 node 1045
-                            Range        : 1.00088
+  L2-norm            : 0.922647
+  Max value          : 0.999984
+  Min value          : -0.00088328 node 1045
+  Range              : 1.00088
   step=2  time=0.2
   Primary solution summary: L2-norm         : 0.000903675
                             Max X-component : 0.000707891
@@ -168,33 +168,33 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.000277141
   Tensile & compressive energies         : 0.237321 3.54944e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0166933
-  Primary solution summary: L2-norm      : 0.922647
-                            Max value    : 0.999984
-                            Min value    : -0.00088328 node 1045
-                            Range        : 1.00088
+  L2-norm            : 0.922647
+  Max value          : 0.999984
+  Min value          : -0.00088328 node 1045
+  Range              : 1.00088
   Dissipated energy:               eps_d : 0.00135777
   step=3  time=0.25
-  Primary solution summary: L2-norm      : 0.921145
-                            Max value    : 0.999977
-                            Min value    : -0.0021619 node 1045
-                            Range        : 1.00216
+  L2-norm            : 0.921145
+  Max value          : 0.999977
+  Min value          : -0.0021619 node 1045
+  Range              : 1.00216
   Primary solution summary: L2-norm         : 0.00113277
                             Max X-component : 0.000875928
                             Max Y-component : 0.00263462
   cycle 0: Res = .*e-1. + 4.82763e-05 = 4.82763e-05  E = 0.000424781 + 0.00136532 = 0.0017901
-  Primary solution summary: L2-norm      : 0.921092
-                            Max value    : 0.999973
-                            Min value    : -0.00240675 node 1045
-                            Range        : 1.00241
+  L2-norm            : 0.921092
+  Max value          : 0.999973
+  Min value          : -0.00240675 node 1045
+  Range              : 1.00241
   step=3  time=0.25
   Primary solution summary: L2-norm         : 0.00113343
                             Max X-component : 0.000873376
                             Max Y-component : 0.00263726
   cycle 1: Res = .*e-1. + 1.83533e-05 = 1.83533e-05  E = 0.000422796 + 0.00136719 = 0.00178999  beta=45
-  Primary solution summary: L2-norm      : 0.921074
-                            Max value    : 0.999972
-                            Min value    : -0.00250282 node 1045
-                            Range        : 1.0025
+  L2-norm            : 0.921074
+  Max value          : 0.999972
+  Min value          : -0.00250282 node 1045
+  Range              : 1.0025
   step=3  time=0.25
   Primary solution summary: L2-norm         : 0.00113361
                             Max X-component : 0.000872397
@@ -206,33 +206,33 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.000420925
   Tensile & compressive energies         : 0.426224 5.5369e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0207971
-  Primary solution summary: L2-norm      : 0.921074
-                            Max value    : 0.999972
-                            Min value    : -0.00250282 node 1045
-                            Range        : 1.0025
+  L2-norm            : 0.921074
+  Max value          : 0.999972
+  Min value          : -0.00250282 node 1045
+  Range              : 1.0025
   Dissipated energy:               eps_d : 0.00136788
   step=4  time=0.3
-  Primary solution summary: L2-norm      : 0.91914
-                            Max value    : 0.999964
-                            Min value    : -0.00382993 node 1045
-                            Range        : 1.00383
+  L2-norm            : 0.91914
+  Max value          : 0.999964
+  Min value          : -0.00382993 node 1045
+  Range              : 1.00383
   Primary solution summary: L2-norm         : 0.00136183
                             Max X-component : 0.00103949
                             Max Y-component : 0.00317386
   cycle 0: Res = .*e-1. + 3.23015e-05 = 3.23015e-05  E = 0.000599406 + 0.00137548 = 0.00197488
-  Primary solution summary: L2-norm      : 0.919063
-                            Max value    : 0.999963
-                            Min value    : -0.00344822 node 1045
-                            Range        : 1.00345
+  L2-norm            : 0.919063
+  Max value          : 0.999963
+  Min value          : -0.00344822 node 1045
+  Range              : 1.00345
   step=4  time=0.3
   Primary solution summary: L2-norm         : 0.0013621
                             Max X-component : 0.00103775
                             Max Y-component : 0.00317449
   cycle 1: Res = .*e-1. + 1.52447e-05 = 1.52447e-05  E = 0.000597956 + 0.00137696 = 0.00197491  beta=-135
-  Primary solution summary: L2-norm      : 0.919036
-                            Max value    : 0.999962
-                            Min value    : -0.00269664 node 1045
-                            Range        : 1.0027
+  L2-norm            : 0.919036
+  Max value          : 0.999962
+  Min value          : -0.00269664 node 1045
+  Range              : 1.0027
   step=4  time=0.3
   Primary solution summary: L2-norm         : 0.0013622
                             Max X-component : 0.00103697
@@ -244,33 +244,33 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.000595119
   Tensile & compressive energies         : 0.65132 7.92594e-05
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0248294
-  Primary solution summary: L2-norm      : 0.919036
-                            Max value    : 0.999962
-                            Min value    : -0.00269664 node 1045
-                            Range        : 1.0027
+  L2-norm            : 0.919036
+  Max value          : 0.999962
+  Min value          : -0.00269664 node 1045
+  Range              : 1.0027
   Dissipated energy:               eps_d : 0.00137759
   step=5  time=0.35
-  Primary solution summary: L2-norm      : 0.916732
-                            Max value    : 0.999953
-                            Min value    : -0.00253685 node 1045
-                            Range        : 1.00254
+  L2-norm            : 0.916732
+  Max value          : 0.999953
+  Min value          : -0.00253685 node 1045
+  Range              : 1.00254
   Primary solution summary: L2-norm         : 0.00159004
                             Max X-component : 0.00120252
                             Max Y-component : 0.00370837
   cycle 0: Res = .*e-1. + 2.97084e-05 = 2.97084e-05  E = 0.000803439 + 0.00138659 = 0.00219003
-  Primary solution summary: L2-norm      : 0.916616
-                            Max value    : 0.999952
-                            Min value    : -0.00200873 node 1045
-                            Range        : 1.00201
+  L2-norm            : 0.916616
+  Max value          : 0.999952
+  Min value          : -0.00200873 node 1045
+  Range              : 1.00201
   step=5  time=0.35
   Primary solution summary: L2-norm         : 0.0015902
                             Max X-component : 0.00120106
                             Max Y-component : 0.00370858
   cycle 1: Res = .*e-1. + 1.41593e-05 = 1.41593e-05  E = 0.000802065 + 0.00138813 = 0.00219019  beta=-135
-  Primary solution summary: L2-norm      : 0.916577
-                            Max value    : 0.999952
-                            Min value    : -0.00185092 node 1045
-                            Range        : 1.00185
+  L2-norm            : 0.916577
+  Max value          : 0.999952
+  Min value          : -0.00185092 node 1045
+  Range              : 1.00185
   step=5  time=0.35
   Primary solution summary: L2-norm         : 0.00159025
                             Max X-component : 0.00120054
@@ -282,16 +282,16 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.000797785
   Tensile & compressive energies         : 0.915837 0.000106859
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0288196
-  Primary solution summary: L2-norm      : 0.916577
-                            Max value    : 0.999952
-                            Min value    : -0.00185092 node 1045
-                            Range        : 1.00185
+  L2-norm            : 0.916577
+  Max value          : 0.999952
+  Min value          : -0.00185092 node 1045
+  Range              : 1.00185
   Dissipated energy:               eps_d : 0.00138871
   step=6  time=0.4
-  Primary solution summary: L2-norm      : 0.913937
-                            Max value    : 0.999946
-                            Min value    : -0.00199172 node 1045
-                            Range        : 1.00199
+  L2-norm            : 0.913937
+  Max value          : 0.999946
+  Min value          : -0.00199172 node 1045
+  Range              : 1.00199
   Primary solution summary: L2-norm         : 0.0018178
                             Max X-component : 0.00136484
                             Max Y-component : 0.00424113
@@ -302,16 +302,16 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.00102965
   Tensile & compressive energies         : 1.213 0.000138003
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0327801
-  Primary solution summary: L2-norm      : 0.913937
-                            Max value    : 0.999946
-                            Min value    : -0.00199172 node 1045
-                            Range        : 1.00199
+  L2-norm            : 0.913937
+  Max value          : 0.999946
+  Min value          : -0.00199172 node 1045
+  Range              : 1.00199
   Dissipated energy:               eps_d : 0.00139965
   step=7  time=0.45
-  Primary solution summary: L2-norm      : 0.910837
-                            Max value    : 0.999937
-                            Min value    : -0.00253538 node 1045
-                            Range        : 1.00254
+  L2-norm            : 0.910837
+  Max value          : 0.999937
+  Min value          : -0.00253538 node 1045
+  Range              : 1.00254
   Primary solution summary: L2-norm         : 0.00204524
                             Max X-component : 0.00152595
                             Max Y-component : 0.00477282
@@ -322,16 +322,16 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.0012855
   Tensile & compressive energies         : 1.55291 0.000172179
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0367127
-  Primary solution summary: L2-norm      : 0.910837
-                            Max value    : 0.999937
-                            Min value    : -0.00253538 node 1045
-                            Range        : 1.00254
+  L2-norm            : 0.910837
+  Max value          : 0.999937
+  Min value          : -0.00253538 node 1045
+  Range              : 1.00254
   Dissipated energy:               eps_d : 0.00141499
   step=8  time=0.5
-  Primary solution summary: L2-norm      : 0.907358
-                            Max value    : 0.999928
-                            Min value    : -0.00268675 node 1045
-                            Range        : 1.00269
+  L2-norm            : 0.907358
+  Max value          : 0.999928
+  Min value          : -0.00268675 node 1045
+  Range              : 1.00269
   Primary solution summary: L2-norm         : 0.00227262
                             Max X-component : 0.00168351
                             Max Y-component : 0.00530372
@@ -342,78 +342,78 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.00156287
   Tensile & compressive energies         : 1.93673 0.000208987
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0406108
-  Primary solution summary: L2-norm      : 0.907358
-                            Max value    : 0.999928
-                            Min value    : -0.00268675 node 1045
-                            Range        : 1.00269
+  L2-norm            : 0.907358
+  Max value          : 0.999928
+  Min value          : -0.00268675 node 1045
+  Range              : 1.00269
   Dissipated energy:               eps_d : 0.00143539
   step=9  time=0.55
-  Primary solution summary: L2-norm      : 0.903502
-                            Max value    : 0.999923
-                            Min value    : -0.00224357 node 1045
-                            Range        : 1.00224
+  L2-norm            : 0.903502
+  Max value          : 0.999923
+  Min value          : -0.00224357 node 1045
+  Range              : 1.00224
   Primary solution summary: L2-norm         : 0.00250002
                             Max X-component : 0.00183662
                             Max Y-component : 0.00583387
   cycle 0: Res = .*e-1. + 1.4392e-05 = 1.4392e-05  E = 0.0018762 + 0.00146219 = 0.00333839
-  Primary solution summary: L2-norm      : 0.902933
-                            Max value    : 0.999923
-                            Min value    : -0.00220966 node 1045
-                            Range        : 1.00221
+  L2-norm            : 0.902933
+  Max value          : 0.999923
+  Min value          : -0.00220966 node 1045
+  Range              : 1.00221
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250032
                             Max X-component : 0.00183089
                             Max Y-component : 0.00583315
   cycle 1: Res = .*e-1. + 1.5347e-05 = 1.5347e-05  E = 0.00186749 + 0.00146964 = 0.00333713  beta=45
-  Primary solution summary: L2-norm      : 0.902544
-                            Max value    : 0.999923
-                            Min value    : -0.00240679 node 1045
-                            Range        : 1.00241
+  L2-norm            : 0.902544
+  Max value          : 0.999923
+  Min value          : -0.00240679 node 1045
+  Range              : 1.00241
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250064
                             Max X-component : 0.00182563
                             Max Y-component : 0.00583255
   cycle 2: Res = .*e-1. + 1.81744e-05 = 1.81744e-05  E = 0.00185983 + 0.00147609 = 0.00333591  beta=44.5125
-  Primary solution summary: L2-norm      : 0.902197
-                            Max value    : 0.999923
-                            Min value    : -0.0023895 node 1045
-                            Range        : 1.00239
+  L2-norm            : 0.902197
+  Max value          : 0.999923
+  Min value          : -0.0023895 node 1045
+  Range              : 1.00239
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250097
                             Max X-component : 0.00182061
                             Max Y-component : 0.00583197
   cycle 3: Res = .*e-1. + 2.39856e-05 = 2.39856e-05  E = 0.00185254 + 0.00148215 = 0.00333469  beta=44.7539
-  Primary solution summary: L2-norm      : 0.901863
-                            Max value    : 0.999923
-                            Min value    : -0.00239694 node 1045
-                            Range        : 1.0024
+  L2-norm            : 0.901863
+  Max value          : 0.999923
+  Min value          : -0.00239694 node 1045
+  Range              : 1.0024
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250131
                             Max X-component : 0.00181582
                             Max Y-component : 0.0058314
   cycle 4: Res = .*e-1. + 2.61322e-05 = 2.61322e-05  E = 0.00184554 + 0.001488 = 0.00333354  beta=43.4433
-  Primary solution summary: L2-norm      : 0.901535
-                            Max value    : 0.999923
-                            Min value    : -0.00207796 node 1045
-                            Range        : 1.00208
+  L2-norm            : 0.901535
+  Max value          : 0.999923
+  Min value          : -0.00207796 node 1045
+  Range              : 1.00208
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250161
                             Max X-component : 0.0018115
                             Max Y-component : 0.00583079
   cycle 5: Res = .*e-1. + 1.95031e-05 = 1.95031e-05  E = 0.00183913 + 0.00149351 = 0.00333265  beta=37.9814
-  Primary solution summary: L2-norm      : 0.901221
-                            Max value    : 0.999923
-                            Min value    : -0.00161361 node 1045
-                            Range        : 1.00161
+  L2-norm            : 0.901221
+  Max value          : 0.999923
+  Min value          : -0.00161361 node 1045
+  Range              : 1.00161
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250185
                             Max X-component : 0.00180778
                             Max Y-component : 0.0058302
   cycle 6: Res = .*e-1. + 1.02255e-05 = 1.02255e-05  E = 0.00183353 + 0.00149851 = 0.00333205  beta=29.5319
-  Primary solution summary: L2-norm      : 0.900934
-                            Max value    : 0.999923
-                            Min value    : -0.00125108 node 1045
-                            Range        : 1.00125
+  L2-norm            : 0.900934
+  Max value          : 0.999923
+  Min value          : -0.00125108 node 1045
+  Range              : 1.00125
   step=9  time=0.55
   Primary solution summary: L2-norm         : 0.00250205
                             Max X-component : 0.00180454
@@ -425,9 +425,9 @@ from expression function: dX=x-0.5; dY=y-0.5; ell=0.015; d=if(below(dX,0.0),abs(
   Bulk energy:                     eps_b : 0.00181035
   Tensile & compressive energies         : 2.45433 0.000241694
   External energy: ((f,u^h)+(t,u^h))^0.5 : -0.0444191
-  Primary solution summary: L2-norm      : 0.900934
-                            Max value    : 0.999923
-                            Min value    : -0.00125108 node 1045
-                            Range        : 1.00125
+  L2-norm            : 0.900934
+  Max value          : 0.999923
+  Min value          : -0.00125108 node 1045
+  Range              : 1.00125
   Dissipated energy:               eps_d : 0.00150299
   Time integration completed.


### PR DESCRIPTION
Downstream of OPM/IFEM#854